### PR TITLE
Collapse collection items in Sidebar

### DIFF
--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -2,18 +2,39 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
+import _ from 'underscore';
+import classnames from 'classnames';
 import { ADMIN_PREFIX } from '../constants';
 import Splitter from '../components/Splitter';
 import { fetchCollections } from '../actions/collections';
 import { capitalize } from '../utils/helpers';
 import { sidebar as SidebarTranslations } from '../constants/lang';
-import _ from 'underscore';
 
 export class Sidebar extends Component {
+
+  constructor(props){
+    super(props);
+
+    this.handleClick = this.handleClick.bind(this);
+    this.state = { collapsedPanel: true };
+  }
 
   componentDidMount() {
     const { fetchCollections } = this.props;
     fetchCollections();
+  }
+
+  handleClick() {
+    if (this.state.collapsedPanel == true) {
+      this.setState({
+        collapsedPanel: false
+      });
+    }
+    else {
+      this.setState({
+        collapsedPanel: true
+      });
+    }
   }
 
   renderCollections(hiddens = []) {
@@ -23,8 +44,8 @@ export class Sidebar extends Component {
       return null;
     }
 
-    return _.map(collections, (col, i) => {
-      if (_.indexOf(hiddens, col.label) == -1) {
+    const collectionItems = _.map(collections, (col, i) => {
+      if (_.indexOf(hiddens, col.label) == -1 && col.label != 'posts') {
         return (
           <li key={i}>
             <Link activeClassName="active" to={`${ADMIN_PREFIX}/collections/${col.label}`}>
@@ -33,7 +54,41 @@ export class Sidebar extends Component {
           </li>
         );
       }
+    }).filter(Boolean);
+
+    const accordionClasses = classnames({
+      "accordion-label": true,
+      "collapsed": this.state.collapsedPanel
     });
+
+    const panelHeight = this.state.collapsedPanel ? 50 : (collectionItems.length + 1) * 50;
+
+    return (
+      <div>
+        {(_.indexOf(hiddens, 'posts') == -1) &&
+          <li>
+            <Link activeClassName="active" to={`${ADMIN_PREFIX}/collections/posts`}>
+              <i className="fa fa-book" />Posts
+            </Link>
+          </li>
+        }
+        {
+          collectionItems.length > 0 &&
+            <li className={accordionClasses} style={{ maxHeight: panelHeight }}>
+              <a onClick={this.handleClick}>
+                <i className="fa fa-book" />Collections
+                <div className="counter">{collectionItems.length}</div>
+                <div className="chevrons">
+                  <i className="fa fa-chevron-up" />
+                </div>
+              </a>
+              <ul>
+                {collectionItems}
+              </ul>
+            </li>
+        }
+      </div>
+    );
   }
 
   render() {

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -22,20 +22,64 @@
     padding: 10px 0;
     list-style: none;
     li {
+      overflow-y: hidden;
+      @include transition(max-height 0.5s);
       a {
         display: block;
         padding: 15px 20px;
         font-size: 17px;
         color: #ebdac1;
-        &.active {
+        &:hover, &.active {
           color: $dark-orange;
         }
       }
       &:hover {
         background-color: #3d3d3d;
+      }
+      &.accordion-label {
+        position: relative;
+        .counter {
+          position: absolute;
+          top: 16px;
+          right: 20px;
+          opacity: 0;
+          width: 30px;
+          padding: 3px;
+          font-size: 12px;
+          font-weight: bold;
+          text-align: center;
+          color: #333;
+          background: #ebdac1;
+          @include border-radius(10px);
+        }
+        .chevrons {
+          position: absolute;
+          top: 14px;
+          right: 20px;
+          @include transition(opacity 1s);
+          i { margin: 0; }
+        }
 
-        a {
-          color: #ffa114;
+        &.collapsed {
+          .counter {
+            opacity: 1;
+            @include transition(opacity 1s 0.25s);
+          }
+          .chevrons {
+            opacity: 0;
+          }
+        }
+        ul {
+          padding: 0;
+          list-style: none;
+
+          li {
+            background: #282828;
+            border-top: 1px solid #333;
+            border-bottom: 1px solid #181818;
+
+            a { padding-left: 40px; }
+          }
         }
       }
     }


### PR DESCRIPTION
  - render a counter showing count of items within panel when collapsed
  - render link to 'Posts' separately

![collapse-collections](https://cloud.githubusercontent.com/assets/12479464/26779812/93184960-4a04-11e7-8441-a75484397aef.jpg)
