### PR TITLE
Render some components as Collapsible 

### DIFF
--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -1,0 +1,74 @@
+import React, { Component, PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
+import classnames from 'classnames';
+
+export default class Collapsible extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.toggleCollapse = this.toggleCollapse.bind(this);
+
+    this.state = {
+      collapsedPanel: true,
+      height: 0
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.height !== nextProps.height) {
+      const panelHeight = nextProps.height;
+      this.setState({ height: panelHeight + panelHeight });
+    }
+  }
+
+  toggleCollapse() {
+    const panelHeight = findDOMNode(this.refs.panel).clientHeight + 2;
+    if (this.state.collapsedPanel) {
+      this.setState({
+        collapsedPanel: false,
+        height: panelHeight
+      });
+    }
+    else {
+      this.setState({
+        collapsedPanel: true,
+        height: 0
+      });
+    }
+  }
+
+  render() {
+    const { label, panel, overflow } = this.props;
+    const collapsibleClasses = classnames({
+      "collapsible-toggle": true,
+      "collapsed": this.state.collapsedPanel
+    });
+
+    const panelClasses = classnames({
+      "collapsible-panel": true,
+      "no-overflow": !overflow
+    });
+
+    return (
+      <div>
+        <div className={collapsibleClasses} onClick={this.toggleCollapse}>
+          {label}
+          <div className="chevrons"><i className="fa fa-chevron-up" /></div>
+        </div>
+        <div className={panelClasses} style={{ maxHeight: this.state.height }}>
+          <div className="panel-content" ref="panel">
+            {panel}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+Collapsible.propTypes = {
+  panel: PropTypes.object.isRequired,
+  label: PropTypes.string.isRequired,
+  height: PropTypes.number,
+  overflow: PropTypes.bool
+};

--- a/src/components/tests/collapsible.spec.js
+++ b/src/components/tests/collapsible.spec.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import Collapsible from '../Collapsible';
+
+const content = (
+  <p>Lorem ipsum dolor sit amet</p>
+);
+const defaultProps = {
+  label: 'Test content',
+  panel: content
+};
+
+function setup(props=defaultProps) {
+  const component = mount(<Collapsible {...props} />);
+
+  return {
+    component,
+    label: component.find('.collapsible-toggle'),
+    panel: component.find('.collapsible-panel')
+  };
+}
+
+describe('Components::Collapsible', () => {
+  it('should render correctly', () => {
+    const { label, panel } = setup();
+    expect(label.text()).toBe('Test content');
+    expect(panel.prop('style').maxHeight).toBe(0);
+  });
+
+  it('should toggle correct class names', () => {
+    let { label } = setup();
+    expect(label.prop('className')).toBe('collapsible-toggle collapsed');
+
+    label.simulate('click');
+    expect(label.prop('className')).toBe('collapsible-toggle');
+
+    label.simulate('click');
+    expect(label.prop('className')).toBe('collapsible-toggle collapsed');
+  });
+
+  it('should assign optional className based on props', () => {
+    let { panel } = setup(Object.assign({}, defaultProps, {
+      overflow: false
+    }));
+    expect(panel.prop('className')).toBe('collapsible-panel no-overflow');
+  });
+
+  it('should render panel with dynamic height', () => {
+    const { component, label, panel } = setup(Object.assign({}, defaultProps, {
+      height: 50
+    }));
+    component.setProps({ height: 50 });
+    label.simulate('click');
+    expect(panel.prop('style').maxHeight).not.toBe(0);
+    component.setProps({ height: 100 });
+    expect(panel.prop('style').maxHeight).toBe(200);
+  });
+});

--- a/src/containers/MetaFields.js
+++ b/src/containers/MetaFields.js
@@ -68,11 +68,8 @@ export class MetaFields extends Component {
       </div>
     ) : (
       <div className="meta-new">
-        <a onClick={() => addField('metadata')} className="tooltip">
-          <i className="fa fa-plus-circle" /> New metadata field
-          <span className="tooltip-text">
-            Metadata will be stored as the <b>YAML front matter</b> within the document.
-          </span>
+        <a onClick={() => addField('metadata')}>
+          <i className="fa fa-plus-circle" /> New front matter field
         </a>
         <small className="tooltip pull-right">
           <i className="fa fa-info-circle" />Special Keys

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -126,6 +126,7 @@ export class DocumentEdit extends Component {
     const filename = rest.join('.');
     const docPath = directory ? `${directory}/${filename}` : filename;
 
+    const inputPath = <InputPath onChange={updatePath} type={collection} path={name} />;
     const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: name, ...front_matter}} />;
 
     const keyboardHandlers = {
@@ -145,8 +146,11 @@ export class DocumentEdit extends Component {
 
         <div className="content-wrapper">
           <div className="content-body">
-            <InputPath onChange={updatePath} type={collection} path={name} />
             <InputTitle onChange={updateTitle} title={title} ref="title" />
+
+            <Collapsible
+              label="Edit Filename or Path"
+              panel={inputPath} />
 
             <Collapsible
               label="Edit Front Matter"

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -1,9 +1,11 @@
 import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
 import _ from 'underscore';
 import { HotKeys } from 'react-hotkeys';
+import Collapsible from '../../components/Collapsible';
 import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
@@ -29,6 +31,8 @@ export class DocumentEdit extends Component {
 
     this.handleClickSave = this.handleClickSave.bind(this);
     this.routerWillLeave = this.routerWillLeave.bind(this);
+
+    this.state = { panelHeight: 0 };
   }
 
   componentDidMount() {
@@ -51,6 +55,11 @@ export class DocumentEdit extends Component {
           `${ADMIN_PREFIX}/collections/${new_path.substring(1)}` // remove `_`
         );
       }
+    }
+
+    if (this.props.new_field_count !== nextProps.new_field_count) {
+      const panelHeight = findDOMNode(this.refs.frontmatter).clientHeight;
+      this.setState({ panelHeight: panelHeight + 60 }); // extra height for various types of metafield field
     }
   }
 
@@ -116,7 +125,8 @@ export class DocumentEdit extends Component {
     const [directory, ...rest] = params.splat;
     const filename = rest.join('.');
     const docPath = directory ? `${directory}/${filename}` : filename;
-    const metafields = injectDefaultFields(config, directory, collection, front_matter);
+
+    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: name, ...front_matter}} />;
 
     const keyboardHandlers = {
       'save': this.handleClickSave,
@@ -137,6 +147,15 @@ export class DocumentEdit extends Component {
           <div className="content-body">
             <InputPath onChange={updatePath} type={collection} path={name} />
             <InputTitle onChange={updateTitle} title={title} ref="title" />
+
+            <Collapsible
+              label="Edit Front Matter"
+              overflow={true}
+              height={this.state.panelHeight}
+              panel={metafields} />
+
+            <Splitter />
+
             <MarkdownEditor
               onChange={updateBody}
               onSave={this.handleClickSave}
@@ -144,7 +163,6 @@ export class DocumentEdit extends Component {
               initialValue={raw_content}
               ref="editor" />
             <Splitter />
-            <Metadata fields={{title, path: name, raw_content, ...metafields}} />
           </div>
 
           <div className="content-side">
@@ -194,7 +212,8 @@ DocumentEdit.propTypes = {
   params: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired
+  config: PropTypes.object.isRequired,
+  new_field_count: PropTypes.number
 };
 
 const mapStateToProps = (state) => ({
@@ -203,7 +222,8 @@ const mapStateToProps = (state) => ({
   fieldChanged: state.metadata.fieldChanged,
   updated: state.collections.updated,
   errors: state.utils.errors,
-  config: state.config.config
+  config: state.config.config,
+  new_field_count: state.metadata.new_field_count
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -1,4 +1,5 @@
 import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
@@ -7,6 +8,7 @@ import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Button from '../../components/Button';
+import Collapsible from '../../components/Collapsible';
 import InputPath from '../../components/form/InputPath';
 import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
@@ -26,6 +28,8 @@ export class DocumentNew extends Component {
 
     this.routerWillLeave = this.routerWillLeave.bind(this);
     this.handleClickSave = this.handleClickSave.bind(this);
+
+    this.state = { panelHeight: 0 };
   }
 
   componentDidMount() {
@@ -40,6 +44,11 @@ export class DocumentNew extends Component {
       browserHistory.push(
         `${ADMIN_PREFIX}/collections/${nextProps.currentDocument.collection}/${splat}`
       );
+    }
+
+    if (this.props.new_field_count !== nextProps.new_field_count) {
+      const panelHeight = findDOMNode(this.refs.frontmatter).clientHeight;
+      this.setState({ panelHeight: panelHeight + 60 }); // extra height for various types of metafield field
     }
   }
 
@@ -93,6 +102,15 @@ export class DocumentNew extends Component {
           <div className="content-body">
             <InputPath onChange={updatePath} type={collection} path="" />
             <InputTitle onChange={updateTitle} title="" ref="title" />
+
+            <Collapsible
+              label="Edit Front Matter"
+              overflow={true}
+              height={this.state.panelHeight}
+              panel={<Metadata fields={{}} ref="frontmatter"/>} />
+
+            <Splitter />
+
             <MarkdownEditor
               onChange={updateBody}
               onSave={this.handleClickSave}
@@ -100,7 +118,6 @@ export class DocumentNew extends Component {
               initialValue=""
               ref="editor" />
             <Splitter />
-            <Metadata fields={metafields} />
           </div>
 
           <div className="content-side">
@@ -130,7 +147,8 @@ DocumentNew.propTypes = {
   params: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired
+  config: PropTypes.object.isRequired,
+  new_field_count: PropTypes.number
 };
 
 const mapStateToProps = (state) => ({
@@ -138,7 +156,8 @@ const mapStateToProps = (state) => ({
   fieldChanged: state.metadata.fieldChanged,
   errors: state.utils.errors,
   updated: state.collections.updated,
-  config: state.config.config
+  config: state.config.config,
+  new_field_count: state.metadata.new_field_count
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -117,6 +117,7 @@ export class PageEdit extends Component {
 
     const title = front_matter && front_matter.title ? front_matter.title : '';
 
+    const inputPath = <InputPath onChange={updatePath} type="pages" path={name} />;
     const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: name, ...front_matter}} />;
 
     return (
@@ -132,8 +133,11 @@ export class PageEdit extends Component {
 
         <div className="content-wrapper">
           <div className="content-body">
-            <InputPath onChange={updatePath} type="pages" path={name} />
             <InputTitle onChange={updateTitle} title={title} ref="title" />
+
+            <Collapsible
+              label="Edit Filename or Path"
+              panel={inputPath} />
 
             <Collapsible
               label="Edit Front Matter"

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -1,9 +1,11 @@
 import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
 import _ from 'underscore';
 import { HotKeys } from 'react-hotkeys';
+import Collapsible from '../../components/Collapsible';
 import Button from '../../components/Button';
 import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
@@ -25,8 +27,10 @@ export class PageEdit extends Component {
   constructor(props) {
     super(props);
 
-    this.handleClickSave = this.handleClickSave.bind(this);
     this.routerWillLeave = this.routerWillLeave.bind(this);
+    this.handleClickSave = this.handleClickSave.bind(this);
+
+    this.state = { panelHeight: 0 };
   }
 
   componentDidMount() {
@@ -46,6 +50,11 @@ export class PageEdit extends Component {
       if (new_path != path) {
         browserHistory.push(`${ADMIN_PREFIX}/pages/${new_path}`);
       }
+    }
+
+    if (this.props.new_field_count !== nextProps.new_field_count) {
+      const panelHeight = findDOMNode(this.refs.frontmatter).clientHeight;
+      this.setState({ panelHeight: panelHeight + 60 }); // extra height for various types of metafield field
     }
   }
 
@@ -107,13 +116,16 @@ export class PageEdit extends Component {
     const [directory, ...rest] = params.splat;
 
     const title = front_matter && front_matter.title ? front_matter.title : '';
-    const metafields = injectDefaultFields(config, directory, 'pages', front_matter);
+
+    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: name, ...front_matter}} />;
 
     return (
       <HotKeys
         handlers={keyboardHandlers}
         className="single">
+
         {errors.length > 0 && <Errors errors={errors} />}
+
         <div className="content-header">
           <Breadcrumbs splat={path} type="pages" />
         </div>
@@ -122,6 +134,15 @@ export class PageEdit extends Component {
           <div className="content-body">
             <InputPath onChange={updatePath} type="pages" path={name} />
             <InputTitle onChange={updateTitle} title={title} ref="title" />
+
+            <Collapsible
+              label="Edit Front Matter"
+              overflow={true}
+              height={this.state.panelHeight}
+              panel={metafields} />
+
+            <Splitter />
+
             <MarkdownEditor
               onChange={updateBody}
               onSave={this.handleClickSave}
@@ -129,7 +150,6 @@ export class PageEdit extends Component {
               initialValue={raw_content}
               ref="editor" />
             <Splitter />
-            <Metadata fields={{title, raw_content, path: name, ...metafields}} />
           </div>
 
           <div className="content-side">
@@ -158,7 +178,6 @@ export class PageEdit extends Component {
       </HotKeys>
     );
   }
-
 }
 
 PageEdit.propTypes = {
@@ -177,7 +196,8 @@ PageEdit.propTypes = {
   params: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired
+  config: PropTypes.object.isRequired,
+  new_field_count: PropTypes.number
 };
 
 const mapStateToProps = (state) => ({
@@ -186,7 +206,8 @@ const mapStateToProps = (state) => ({
   fieldChanged: state.metadata.fieldChanged,
   updated: state.pages.updated,
   errors: state.utils.errors,
-  config: state.config.config
+  config: state.config.config,
+  new_field_count: state.metadata.new_field_count
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -1,4 +1,5 @@
 import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
@@ -7,6 +8,7 @@ import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Button from '../../components/Button';
+import Collapsible from '../../components/Collapsible';
 import InputPath from '../../components/form/InputPath';
 import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
@@ -26,6 +28,8 @@ export class PageNew extends Component {
 
     this.routerWillLeave = this.routerWillLeave.bind(this);
     this.handleClickSave = this.handleClickSave.bind(this);
+
+    this.state = { panelHeight: 0 };
   }
 
   componentDidMount() {
@@ -36,6 +40,11 @@ export class PageNew extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
       browserHistory.push(`${ADMIN_PREFIX}/pages/${nextProps.page.path}`);
+    }
+
+    if (this.props.new_field_count !== nextProps.new_field_count) {
+      const panelHeight = findDOMNode(this.refs.frontmatter).clientHeight;
+      this.setState({ panelHeight: panelHeight + 60 }); // extra height for various types of metafield field
     }
   }
 
@@ -73,7 +82,6 @@ export class PageNew extends Component {
       'save': this.handleClickSave,
     };
 
-    const metafields = injectDefaultFields(config, params.splat, 'pages');
     return (
       <HotKeys handlers={keyboardHandlers} className="single">
         {errors.length > 0 && <Errors errors={errors} />}
@@ -85,6 +93,15 @@ export class PageNew extends Component {
           <div className="content-body">
             <InputPath onChange={updatePath} type="pages" path="" />
             <InputTitle onChange={updateTitle} title="" ref="title" />
+
+            <Collapsible
+              label="Edit Front Matter"
+              overflow={true}
+              height={this.state.panelHeight}
+              panel={<Metadata fields={{}} ref="frontmatter"/>} />
+
+            <Splitter />
+
             <MarkdownEditor
               onChange={updateBody}
               onSave={this.handleClickSave}
@@ -92,7 +109,6 @@ export class PageNew extends Component {
               initialValue=""
               ref="editor" />
             <Splitter />
-            <Metadata fields={metafields} />
           </div>
 
           <div className="content-side">
@@ -123,7 +139,8 @@ PageNew.propTypes = {
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired
+  config: PropTypes.object.isRequired,
+  new_field_count: PropTypes.number
 };
 
 const mapStateToProps = (state) => ({
@@ -131,7 +148,8 @@ const mapStateToProps = (state) => ({
   fieldChanged: state.metadata.fieldChanged,
   errors: state.utils.errors,
   updated: state.pages.updated,
-  config: state.config.config
+  config: state.config.config,
+  new_field_count: state.metadata.new_field_count
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/styles/collapsible.scss
+++ b/src/styles/collapsible.scss
@@ -49,6 +49,17 @@
     border: 1px solid $border-color;
     .metafields { margin-bottom: 0; }
   }
+  .input-path {
+    label { display: none; }
+    textarea {
+      margin-top: 0;
+      margin-bottom: 0;
+      padding: 11px;
+      background: white;
+      border: 1px solid $border-color;
+      @include border-radius($border-radius);
+    }
+  }
   .tooltip-text {
     right: 0 !important;
     &:after {

--- a/src/styles/collapsible.scss
+++ b/src/styles/collapsible.scss
@@ -1,0 +1,55 @@
+.collapsible-toggle {
+  padding: 15px;
+  cursor: pointer;
+  color: white;
+  background-color: #4f4f4f;
+  border: 1px solid #4f4f4f;
+  transition: all 0.5s;
+  z-index: 90;
+
+  .chevrons {
+    float: right;
+    transition: transform 0.5s;
+    i { margin: 0; }
+  }
+
+  &.collapsed {
+    margin-bottom: 8px;
+    color: #777;
+    background-color: #fdfdfd;
+    border-color: #eee;
+    @include border-radius($border-radius);
+    @include box-shadow(0 1px #dedede);
+    .chevrons {
+      color: #999;
+      transform: rotate(180deg);
+    }
+    + .collapsible-panel {
+      border: none;
+      margin-bottom: 0;
+      overflow: hidden;
+      + .splitter {
+        display: none;
+      }
+    }
+  }
+
+  + .collapsible-panel {
+    transition: all 0.5s;
+    margin-bottom: 20px;
+    .panel-content {
+      margin-top: -1px;
+    }
+  }
+}
+
+.collapsible-panel {
+  .panel-content {
+    padding: 15px;
+    border: 1px solid $border-color;
+  }
+}
+
+.no-overflow {
+  overflow: hidden;
+}

--- a/src/styles/collapsible.scss
+++ b/src/styles/collapsible.scss
@@ -47,6 +47,14 @@
   .panel-content {
     padding: 15px;
     border: 1px solid $border-color;
+    .metafields { margin-bottom: 0; }
+  }
+  .tooltip-text {
+    right: 0 !important;
+    &:after {
+      left: 90% !important;
+      right: 5%;
+    }
   }
 }
 

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -193,6 +193,7 @@
       color: $white;
       text-align: center;
       background: $dark-gray;
+      z-index: 999;
       @include border-radius($border-radius);
       @include box-shadow(0px 2px 8px 2px rgba(0, 0, 0, 0.08));
       &:after {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -13,6 +13,7 @@
 @import "editor";
 @import "button";
 @import "staticfiles";
+@import "collapsible";
 
 * {
   box-sizing: border-box;


### PR DESCRIPTION
With this, `InputPath` in edit-views and `Metafields` components will render as collapsible entities

![collapsibles-c](https://cloud.githubusercontent.com/assets/12479464/26818226/811d74a2-4ab7-11e7-8e34-1bfc2f912c94.png)

---

![collapsibles-o](https://cloud.githubusercontent.com/assets/12479464/26818237/8a33ebde-4ab7-11e7-9b9e-fb100682721f.png)
