### PR TITLE
Unlock directory traversal within context

### DIFF
--- a/src/actions/tests/collections.spec.js
+++ b/src/actions/tests/collections.spec.js
@@ -125,9 +125,9 @@ describe('Actions::Collections', () => {
       { type: types.PUT_DOCUMENT_SUCCESS, doc }
     ];
 
-    const store = mockStore({metadata: { metadata: doc}});
+    const store = mockStore({metadata: { metadata: doc }});
 
-    return store.dispatch(actions.putDocument(doc.collection, '', filename))
+    return store.dispatch(actions.putDocument('edit', doc.collection, '', filename))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -143,9 +143,9 @@ describe('Actions::Collections', () => {
       { type: types.PUT_DOCUMENT_FAILURE, error: 'something awful happened' }
     ];
 
-    const store = mockStore({metadata: { metadata: doc}});
+    const store = mockStore({metadata: { metadata: doc }});
 
-    return store.dispatch(actions.putDocument(doc.collection, filename))
+    return store.dispatch(actions.putDocument('edit', doc.collection, filename))
       .then(() => {
         expect(store.getActions()[1].type).toEqual(expectedActions[1].type);
       });
@@ -161,9 +161,9 @@ describe('Actions::Collections', () => {
       { type: types.PUT_DOCUMENT_SUCCESS, doc }
     ];
 
-    const store = mockStore({metadata: { metadata: new_doc}});
+    const store = mockStore({metadata: { metadata: new_doc }});
 
-    return store.dispatch(actions.createDocument(new_doc.collection, ''))
+    return store.dispatch(actions.putDocument('create', new_doc.collection, ''))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -179,9 +179,9 @@ describe('Actions::Collections', () => {
       { type: types.PUT_DOCUMENT_SUCCESS, doc }
     ];
 
-    const store = mockStore({metadata: { metadata: {...new_doc, path: ''}}});
+    const store = mockStore({metadata: { metadata: {...new_doc, path: ''} }});
 
-    return store.dispatch(actions.createDocument(new_doc.collection, ''))
+    return store.dispatch(actions.putDocument('create', new_doc.collection, ''))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -207,7 +207,7 @@ describe('Actions::Collections', () => {
       }
     });
 
-    return store.dispatch(actions.createDocument(new_post_with_date.collection, ''))
+    return store.dispatch(actions.putDocument('create', new_post_with_date.collection, ''))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -245,7 +245,7 @@ describe('Actions::Collections', () => {
       metadata: { metadata: { title: 'test', path: '2016-33-33-title.md'} }
     });
 
-    store.dispatch(actions.putDocument('posts', doc.id));
+    store.dispatch(actions.putDocument('edit', 'posts', doc.id));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/src/actions/tests/pages.spec.js
+++ b/src/actions/tests/pages.spec.js
@@ -99,7 +99,7 @@ describe('Actions::Pages', () => {
 
     const store = mockStore({metadata: { metadata: page}});
 
-    return store.dispatch(actions.putPage('', 'page.md'))
+    return store.dispatch(actions.putPage('edit', '', 'page.md'))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -115,9 +115,9 @@ describe('Actions::Pages', () => {
       { type: types.PUT_PAGE_SUCCESS, page }
     ];
 
-    const store = mockStore({metadata: { metadata: page}});
+    const store = mockStore({metadata: { metadata: page }});
 
-    return store.dispatch(actions.createPage(''))
+    return store.dispatch(actions.putPage('create'))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -133,9 +133,9 @@ describe('Actions::Pages', () => {
       { type: types.PUT_PAGE_SUCCESS, page }
     ];
 
-    const store = mockStore({metadata: { metadata: {...new_page, path: ''}}});
+    const store = mockStore({metadata: { metadata: {...new_page, path: ''} }});
 
-    return store.dispatch(actions.createPage(''))
+    return store.dispatch(actions.putPage('create'))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -164,12 +164,13 @@ describe('Actions::Pages', () => {
       {
         type: types.VALIDATION_ERROR,
         errors: [
+          "The title is required.",
           "The filename is not valid."
         ]
       }
     ];
 
-    const store = mockStore({metadata: { metadata: { path: '.invalid.'} }});
+    const store = mockStore({metadata: { metadata: { path: '', title: '' } }});
 
     store.dispatch(actions.putPage(page.name));
     expect(store.getActions()).toEqual(expectedActions);

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -74,10 +74,12 @@ export class DataFileEdit extends Component {
   }
 
   toggleView() {
-    const { datafile } = this.props;
+    const { datafile, params } = this.props;
+    const [directory, ...rest] = params.splat;
+    const path = directory ? `${directory}/${datafile.slug}` : datafile.slug;
     this.setState({
       guiView: !this.state.guiView,
-      guiPath: datafile.slug,
+      guiPath: path,
       extn: datafile.ext
     });
   }
@@ -117,8 +119,7 @@ export class DataFileEdit extends Component {
         mode = 'editor';
       }
 
-      const data_path = directory ? (data_dir + `${directory}/` + name) :
-                                    (data_dir + name);
+      const data_path = data_dir + name;
 
       const new_path = (data_path != path) ? data_path : '';
       putDataFile(directory, filename, data, new_path, mode);
@@ -230,7 +231,7 @@ export class DataFileEdit extends Component {
       <InputPath
         onChange={onDataFileChanged}
         type="data files"
-        path={filename}
+        path={relative_path}
         ref="inputpath" />
     );
 

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -87,7 +87,7 @@ export class DocumentEdit extends Component {
       const collection = params.collection_name;
       const [directory, ...rest] = params.splat;
       const filename = rest.join('.');
-      putDocument(collection, directory, filename);
+      putDocument('edit', collection, directory, filename);
     }
   }
 
@@ -126,8 +126,8 @@ export class DocumentEdit extends Component {
     const filename = rest.join('.');
     const docPath = directory ? `${directory}/${filename}` : filename;
 
-    const inputPath = <InputPath onChange={updatePath} type={collection} path={name} />;
-    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: name, ...front_matter}} />;
+    const inputPath = <InputPath onChange={updatePath} type={collection} path={docPath} />;
+    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: docPath, ...front_matter}} />;
 
     const keyboardHandlers = {
       'save': this.handleClickSave,

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -14,7 +14,7 @@ import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
 import Metadata from '../../containers/MetaFields';
 import { updateTitle, updateBody, updatePath } from '../../actions/metadata';
-import { createDocument } from '../../actions/collections';
+import { putDocument } from '../../actions/collections';
 import { clearErrors } from '../../actions/utils';
 import { getLeaveMessage } from '../../constants/lang';
 import { injectDefaultFields } from '../../utils/metadata';
@@ -67,14 +67,14 @@ export class DocumentNew extends Component {
   }
 
   handleClickSave(e) {
-    const { fieldChanged, createDocument, params } = this.props;
+    const { fieldChanged, putDocument, params } = this.props;
 
     // Prevent the default event from bubbling
     preventDefault(e);
 
     if (fieldChanged) {
       const { collection_name, splat } = params;
-      createDocument(collection_name, splat);
+      putDocument('create', collection_name, splat);
     }
   }
 
@@ -136,7 +136,7 @@ export class DocumentNew extends Component {
 }
 
 DocumentNew.propTypes = {
-  createDocument: PropTypes.func.isRequired,
+  putDocument: PropTypes.func.isRequired,
   updateTitle: PropTypes.func.isRequired,
   updateBody: PropTypes.func.isRequired,
   updatePath: PropTypes.func.isRequired,
@@ -164,7 +164,7 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   updateTitle,
   updateBody,
   updatePath,
-  createDocument,
+  putDocument,
   clearErrors
 }, dispatch);
 

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -81,7 +81,7 @@ export class PageEdit extends Component {
     if (fieldChanged) {
       const [directory, ...rest] = params.splat;
       const filename = rest.join('.');
-      putPage(directory, filename);
+      putPage('edit', directory, filename);
     }
   }
 
@@ -117,8 +117,8 @@ export class PageEdit extends Component {
 
     const title = front_matter && front_matter.title ? front_matter.title : '';
 
-    const inputPath = <InputPath onChange={updatePath} type="pages" path={name} />;
-    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: name, ...front_matter}} />;
+    const inputPath = <InputPath onChange={updatePath} type="pages" path={path} />;
+    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: path, ...front_matter}} />;
 
     return (
       <HotKeys

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -14,7 +14,7 @@ import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
 import Metadata from '../../containers/MetaFields';
 import { updateTitle, updateBody, updatePath, updateDraft } from '../../actions/metadata';
-import { createPage } from '../../actions/pages';
+import { putPage } from '../../actions/pages';
 import { clearErrors } from '../../actions/utils';
 import { getLeaveMessage } from '../../constants/lang';
 import { injectDefaultFields } from '../../utils/metadata';
@@ -63,13 +63,13 @@ export class PageNew extends Component {
   }
 
   handleClickSave(e) {
-    const { fieldChanged, createPage, params } = this.props;
+    const { fieldChanged, putPage, params } = this.props;
 
     // Prevent the default event from bubbling
     preventDefault(e);
 
     if (fieldChanged) {
-      createPage(params.splat);
+      putPage('create', params.splat);
     }
   }
 
@@ -127,7 +127,7 @@ export class PageNew extends Component {
 }
 
 PageNew.propTypes = {
-  createPage: PropTypes.func.isRequired,
+  putPage: PropTypes.func.isRequired,
   updateTitle: PropTypes.func.isRequired,
   updateBody: PropTypes.func.isRequired,
   updatePath: PropTypes.func.isRequired,
@@ -157,7 +157,7 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   updateBody,
   updatePath,
   updateDraft,
-  createPage,
+  putPage,
   clearErrors
 }, dispatch);
 

--- a/src/containers/views/tests/datafileedit.spec.js
+++ b/src/containers/views/tests/datafileedit.spec.js
@@ -93,7 +93,7 @@ describe('Containers::DataFileEdit', () => {
     });
     toggleButton.simulate('click');
     expect(component.state()).toEqual({
-      'guiPath': 'authors',
+      'guiPath': 'movies/authors',
       'extn': '.yml',
       'guiView': true
     });

--- a/src/containers/views/tests/documentnew.spec.js
+++ b/src/containers/views/tests/documentnew.spec.js
@@ -19,7 +19,7 @@ const defaultProps = {
 
 const setup = (props = defaultProps) => {
   const actions = {
-    createDocument: jest.fn(),
+    putDocument: jest.fn(),
     updateTitle: jest.fn(),
     updateBody: jest.fn(),
     updatePath: jest.fn(),
@@ -50,17 +50,17 @@ describe('Containers::DocumentNew', () => {
     expect(errors.node).toBeTruthy();
   });
 
-  it('should not call createDocument if a field is not changed.', () => {
+  it('should not call putDocument if a field is not changed.', () => {
     const { saveButton, actions } = setup();
     saveButton.simulate('click');
-    expect(actions.createDocument).not.toHaveBeenCalled();
+    expect(actions.putDocument).not.toHaveBeenCalled();
   });
 
-  it('should call createDocument if a field is changed.', () => {
+  it('should call putDocument if a field is changed.', () => {
     const { saveButton, actions } = setup(Object.assign({}, defaultProps, {
       fieldChanged: true
     }));
     saveButton.simulate('click');
-    expect(actions.createDocument).toHaveBeenCalled();
+    expect(actions.putDocument).toHaveBeenCalled();
   });
 });

--- a/src/containers/views/tests/pagenew.spec.js
+++ b/src/containers/views/tests/pagenew.spec.js
@@ -19,7 +19,7 @@ const defaultProps = {
 
 function setup(props = defaultProps) {
   const actions = {
-    createPage: jest.fn(),
+    putPage: jest.fn(),
     updateTitle: jest.fn(),
     updateBody: jest.fn(),
     updatePath: jest.fn(),
@@ -53,17 +53,17 @@ describe('Containers::PageNew', () => {
     expect(errors.node).toBeTruthy();
   });
 
-  it('should not call createPage if a field is not changed.', () => {
+  it('should not call putPage if a field is not changed.', () => {
     const { saveButton, actions } = setup();
     saveButton.simulate('click');
-    expect(actions.createPage).not.toHaveBeenCalled();
+    expect(actions.putPage).not.toHaveBeenCalled();
   });
 
-  it('should call createPage if a field is changed.', () => {
+  it('should call putPage if a field is changed.', () => {
     const { saveButton, actions } = setup(Object.assign({}, defaultProps, {
       fieldChanged: true
     }));
     saveButton.simulate('click');
-    expect(actions.createPage).toHaveBeenCalled();
+    expect(actions.putPage).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
With this, `InputPath` will display the full path relative to its type:

Breadcrumbs | InputPath value | Allowed ancestor-dir traversal
--- | --- | ---
**Pages / page-dir / page.md** | page-dir/page.md | upto `site.source`
**Posts / post-dir / 2017-03-01-post.md** | post-dir/2017-03-01-post.md | upto `site.source/_posts`
**Puppies / retrievers / rover.md** | retrievers/rover.md | upto `site.source/_puppies`
**Data Files / movies / genres / fiction.yml** | movies/genres/fiction.yml | upto `site.data_dir`

The path can then be edited to move a file deeper into the file tree or into its ancestor directories