### PR TITLE
update views for Drafts

### DIFF
--- a/src/actions/drafts.js
+++ b/src/actions/drafts.js
@@ -59,8 +59,7 @@ export function putDraft(mode, directory, filename = '') {
       filename = path.replace('_drafts/', '');
       payload = { front_matter, raw_content };
     } else {
-      let writePath = directory ? `_drafts/${directory}/${path}` :
-        `_drafts/${path}`;
+      let writePath = `_drafts/${path}`;
       payload = { path: writePath, front_matter, raw_content };
     }
 

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -149,17 +149,15 @@ export class Sidebar extends Component {
       <div className="sidebar">
         <Link className="logo" to={`${ADMIN_PREFIX}/pages`} />
         <ul className="routes">
-          {this.renderCollections(hiddenLinks)}
-          {
-            config && config.show_drafts &&
-              <li>
-                <Link activeClassName="active" to={`${ADMIN_PREFIX}/drafts`}>
-                  <i className="fa fa-edit" />
-                  {SidebarTranslations.drafts}
-                </Link>
-                { !hiddenLinks.includes('posts') && <Splitter /> }
-              </li>
+          {config && config.show_drafts &&
+            <li>
+              <Link activeClassName="active" to={`${ADMIN_PREFIX}/drafts`}>
+                <i className="fa fa-edit" />
+                {SidebarTranslations.drafts}
+              </Link>
+            </li>
           }
+          {this.renderCollections(hiddenLinks)}
           {links}
         </ul>
       </div>

--- a/src/containers/views/DraftEdit.js
+++ b/src/containers/views/DraftEdit.js
@@ -114,8 +114,8 @@ export class DraftEdit extends Component {
     const [directory, ...rest] = params.splat;
 
     const title = front_matter && front_matter.title ? front_matter.title : '';
-    const inputPath = <InputPath onChange={updatePath} type="drafts" path={name} />;
-    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: name, ...front_matter}} />;
+    const inputPath = <InputPath onChange={updatePath} type="drafts" path={relative_path} />;
+    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: relative_path, ...front_matter}} />;
 
     return (
       <HotKeys

--- a/src/containers/views/DraftEdit.js
+++ b/src/containers/views/DraftEdit.js
@@ -110,7 +110,7 @@ export class DraftEdit extends Component {
       'save': this.handleClickSave,
     };
 
-    const { name, raw_content, collection, http_url, front_matter } = draft;
+    const { name, relative_path, raw_content, collection, http_url, front_matter } = draft;
     const [directory, ...rest] = params.splat;
 
     const title = front_matter && front_matter.title ? front_matter.title : '';
@@ -123,7 +123,7 @@ export class DraftEdit extends Component {
         className="single">
         {errors.length > 0 && <Errors errors={errors} />}
         <div className="content-header">
-          <Breadcrumbs splat={directory || ''} type="drafts" />
+          <Breadcrumbs splat={relative_path} type="drafts" />
         </div>
 
         <div className="content-wrapper">

--- a/src/containers/views/DraftEdit.js
+++ b/src/containers/views/DraftEdit.js
@@ -1,9 +1,11 @@
 import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
 import _ from 'underscore';
 import { HotKeys } from 'react-hotkeys';
+import Collapsible from '../../components/Collapsible';
 import Button from '../../components/Button';
 import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
@@ -27,6 +29,8 @@ export class DraftEdit extends Component {
 
     this.routerWillLeave = this.routerWillLeave.bind(this);
     this.handleClickSave = this.handleClickSave.bind(this);
+
+    this.state = { panelHeight: 0 };
   }
 
   componentDidMount() {
@@ -46,6 +50,11 @@ export class DraftEdit extends Component {
       if (new_path != path) {
         browserHistory.push(`${ADMIN_PREFIX}/drafts/${nextProps.draft.relative_path}`);
       }
+    }
+
+    if (this.props.new_field_count !== nextProps.new_field_count) {
+      const panelHeight = findDOMNode(this.refs.frontmatter).clientHeight;
+      this.setState({ panelHeight: panelHeight + 60 }); // extra height for various types of metafield field
     }
   }
 
@@ -105,7 +114,8 @@ export class DraftEdit extends Component {
     const [directory, ...rest] = params.splat;
 
     const title = front_matter && front_matter.title ? front_matter.title : '';
-    const metafields = injectDefaultFields(config, directory, collection, front_matter);
+    const inputPath = <InputPath onChange={updatePath} type="drafts" path={name} />;
+    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: name, ...front_matter}} />;
 
     return (
       <HotKeys
@@ -118,8 +128,20 @@ export class DraftEdit extends Component {
 
         <div className="content-wrapper">
           <div className="content-body">
-            <InputPath onChange={updatePath} type="drafts" path={name} />
             <InputTitle onChange={updateTitle} title={title} ref="title" />
+
+            <Collapsible
+              label="Edit Filename or Path"
+              panel={inputPath} />
+
+            <Collapsible
+              label="Edit Front Matter"
+              overflow={true}
+              height={this.state.panelHeight}
+              panel={metafields} />
+
+            <Splitter />
+
             <MarkdownEditor
               onChange={updateBody}
               onSave={this.handleClickSave}
@@ -127,7 +149,6 @@ export class DraftEdit extends Component {
               initialValue={raw_content}
               ref="editor" />
             <Splitter />
-            <Metadata fields={{title, raw_content, path: name, ...metafields}} />
           </div>
 
           <div className="content-side">
@@ -175,7 +196,8 @@ DraftEdit.propTypes = {
   params: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired
+  config: PropTypes.object.isRequired,
+  new_field_count: PropTypes.number
 };
 
 const mapStateToProps = (state) => ({
@@ -184,7 +206,8 @@ const mapStateToProps = (state) => ({
   fieldChanged: state.metadata.fieldChanged,
   updated: state.drafts.updated,
   errors: state.utils.errors,
-  config: state.config.config
+  config: state.config.config,
+  new_field_count: state.metadata.new_field_count
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/containers/views/DraftNew.js
+++ b/src/containers/views/DraftNew.js
@@ -88,9 +88,7 @@ export class DraftNew extends Component {
         className="single">
         {errors.length > 0 && <Errors errors={errors} />}
         <div className="content-header">
-          <Breadcrumbs
-            type="drafts"
-            splat={params.splat || ''} />
+          <Breadcrumbs splat={params.splat || ''} type="drafts" />
         </div>
 
         <div className="content-wrapper">

--- a/src/containers/views/DraftNew.js
+++ b/src/containers/views/DraftNew.js
@@ -1,4 +1,5 @@
 import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
@@ -7,6 +8,7 @@ import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Button from '../../components/Button';
+import Collapsible from '../../components/Collapsible';
 import InputPath from '../../components/form/InputPath';
 import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
@@ -26,6 +28,8 @@ export class DraftNew extends Component {
 
     this.routerWillLeave = this.routerWillLeave.bind(this);
     this.handleClickSave = this.handleClickSave.bind(this);
+
+    this.state = { panelHeight: 0 };
   }
 
   componentDidMount() {
@@ -36,6 +40,11 @@ export class DraftNew extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
       browserHistory.push(`${ADMIN_PREFIX}/drafts/${nextProps.draft.relative_path}`);
+    }
+
+    if (this.props.new_field_count !== nextProps.new_field_count) {
+      const panelHeight = findDOMNode(this.refs.frontmatter).clientHeight;
+      this.setState({ panelHeight: panelHeight + 60 }); // extra height for various types of metafield field
     }
   }
 
@@ -68,7 +77,6 @@ export class DraftNew extends Component {
     const {
       errors, updated, updateTitle, updateBody, updatePath, fieldChanged, params, config
     } = this.props;
-    const metafields = injectDefaultFields(config, params.splat, 'posts');
 
     const keyboardHandlers = {
       'save': this.handleClickSave,
@@ -89,6 +97,15 @@ export class DraftNew extends Component {
           <div className="content-body">
             <InputPath onChange={updatePath} type="drafts" path="" />
             <InputTitle onChange={updateTitle} title="" ref="title" />
+
+            <Collapsible
+              label="Edit Front Matter"
+              overflow={true}
+              height={this.state.panelHeight}
+              panel={<Metadata fields={{}} ref="frontmatter"/>} />
+
+            <Splitter />
+
             <MarkdownEditor
               onChange={updateBody}
               onSave={this.handleClickSave}
@@ -96,7 +113,6 @@ export class DraftNew extends Component {
               initialValue=""
               ref="editor" />
             <Splitter />
-            <Metadata fields={metafields} />
           </div>
 
           <div className="content-side">
@@ -127,7 +143,8 @@ DraftNew.propTypes = {
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired
+  config: PropTypes.object.isRequired,
+  new_field_count: PropTypes.number
 };
 
 const mapStateToProps = (state) => ({
@@ -135,7 +152,8 @@ const mapStateToProps = (state) => ({
   fieldChanged: state.metadata.fieldChanged,
   errors: state.utils.errors,
   updated: state.drafts.updated,
-  config: state.config.config
+  config: state.config.config,
+  new_field_count: state.metadata.new_field_count
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({


### PR DESCRIPTION
- Move Sidebar link to render above the link to Posts
- Add recent feature additions to views for Drafts:
  - add Collapsible components
  - add filename to Breadcrumbs
  - unlock directory traversal for files in subdirectories up to `site.source/_drafts/`