### PR TITLE
Add image-preview for image files in theme-gem

### DIFF
--- a/lib/jekyll-admin/server/theme.rb
+++ b/lib/jekyll-admin/server/theme.rb
@@ -85,6 +85,7 @@ module JekyllAdmin
         Dir["#{directory_path}/*"].reject { |e| File.directory?(e) }.map! do |e|
           {
             :path     => relative_path_of(e).sub("#{splats.first}/", ""),
+            :extname  => File.extname(e),
             :http_url => http_url(e),
             :api_url  => api_url(e),
           }

--- a/spec/jekyll-admin/server/theme_spec.rb
+++ b/spec/jekyll-admin/server/theme_spec.rb
@@ -48,6 +48,7 @@ describe "theme" do
     it "returns the requested directory" do
       expected = {
         "path"     => "default.html",
+        "extname"  => ".html",
         "api_url"  => "http://example.org/_api/theme/_layouts/default.html",
         "http_url" => nil,
       }
@@ -60,6 +61,7 @@ describe "theme" do
     it "returns subdirectories" do
       expected = {
         "path"     => "icon-dark.png",
+        "extname"  => ".png",
         "http_url" => "http://example.org/assets/images/icon-dark.png",
         "api_url"  => "http://example.org/_api/theme/assets/images/icon-dark.png",
       }

--- a/src/containers/views/ThemeDirectory.js
+++ b/src/containers/views/ThemeDirectory.js
@@ -23,29 +23,42 @@ export class TemplateDirectory extends Component {
   }
 
   renderFileRow(splat, file) {
-    const { path, api_url, http_url } = file;
+    const { path, extname, api_url, http_url } = file;
     const to = `${ADMIN_PREFIX}/theme/${splat}/${path}`;
+    const image = /png|jpg|jpeg|gif|svg|ico/i.test(extname.substring(1));
+
     return (
       <tr key={path}>
         <td className="row-title">
-          <strong>
-            <Link to={http_url ? null : to}>
-              <i className="fa fa-file-text-o" aria-hidden="true" />
-              {path}
-            </Link>
-          </strong>
-        </td>
-        <td>
-          {http_url &&
-            <div className="row-actions">
-              <Button
-                to={http_url}
-                type="view"
-                icon="eye"
-                active={true}
-                thin />
-            </div>
-          }
+        {
+          http_url && image &&
+            <strong>
+              <a href={http_url} target="_blank">
+                <div className="image-container">
+                  <img src={http_url} />
+                  <div className="image-filename">{path}</div>
+                </div>
+              </a>
+            </strong>
+        }
+        {
+          http_url && !image &&
+            <strong>
+              <a href={http_url} target="_blank">
+                <i className="fa fa-file-text-o" aria-hidden="true" />
+                {path}
+              </a>
+            </strong>
+        }
+        {
+          !http_url &&
+            <strong>
+              <Link to={to}>
+                <i className="fa fa-file-text-o" aria-hidden="true" />
+                {path}
+              </Link>
+            </strong>
+        }
         </td>
       </tr>
     );
@@ -64,7 +77,6 @@ export class TemplateDirectory extends Component {
             </Link>
           </strong>
         </td>
-        <td />
       </tr>
     );
   }
@@ -97,7 +109,6 @@ export class TemplateDirectory extends Component {
               <thead>
                 <tr>
                   <th>Contents</th>
-                  <th />
                 </tr>
               </thead>
               <tbody>

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -33,3 +33,15 @@
   background: #2d2f27;
   box-shadow: 0 1px 2px #d9d9d9;
 }
+
+.image-container {
+  max-width: 150px;
+  margin: 0 auto;
+  img {
+    width: 100%;
+  }
+  .image-filename {
+    padding: 15px 0;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
Preview within table row itself.. one image per row.
Any non-image file will render as regular row.

![img-preview](https://user-images.githubusercontent.com/12479464/27383488-d7830d6e-56a8-11e7-8d45-2cc103095940.png)
