### PR TITLE
Use admin version from dashboard's meta object

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,2 +1,1 @@
-export const VERSION = 'v0.5.1';
 export const ADMIN_PREFIX = '/admin';

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux';
 import { HotKeys } from 'react-hotkeys';
 
 import { fetchConfig } from '../actions/config';
+import { fetchMeta } from '../actions/dashboard';
 import keyboardShortcuts from '../constants/keyboardShortcuts';
 
 // Components
@@ -14,8 +15,9 @@ import Notifications from './Notifications';
 class App extends Component {
 
   componentDidMount() {
-    const { fetchConfig } = this.props;
+    const { fetchConfig, fetchMeta } = this.props;
     fetchConfig();
+    fetchMeta();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -27,11 +29,13 @@ class App extends Component {
 
   render() {
     const { isFetching } = this.props;
-    const config = this.props.config.content;
 
     if (isFetching) {
       return null;
     }
+
+    const config = this.props.config.content;
+    const admin = this.props.meta.admin;
 
     return (
       <HotKeys
@@ -42,7 +46,7 @@ class App extends Component {
           <div>
             <Sidebar config={config} />
             <div className="container">
-              <Header config={config} />
+              <Header config={config} admin={admin} />
               <div className="content">
                 {this.props.children}
               </div>
@@ -58,19 +62,23 @@ class App extends Component {
 App.propTypes = {
   children: PropTypes.element,
   fetchConfig: PropTypes.func.isRequired,
+  fetchMeta: PropTypes.func.isRequired,
   config: PropTypes.object.isRequired,
+  meta: PropTypes.object.isRequired,
   isFetching: PropTypes.bool.isRequired,
   updated: PropTypes.bool
 };
 
 const mapStateToProps = (state) => ({
   config: state.config.config,
+  meta: state.dashboard.meta,
   updated: state.config.updated,
   isFetching: state.config.isFetching,
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
-  fetchConfig
+  fetchConfig,
+  fetchMeta
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -2,12 +2,11 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
-import { VERSION } from '../constants';
 
 export class Header extends Component {
 
   render() {
-    const { config } = this.props;
+    const { config, admin } = this.props;
     return (
       <div className="header">
         <h3 className="title">
@@ -16,13 +15,14 @@ export class Header extends Component {
             <span>{config.title || 'You have no title!'}</span>
           </Link>
         </h3>
-        <span className="version">{VERSION}</span>
+        <span className="version">{admin.version}</span>
       </div>
     );
   }
 }
 
 Header.propTypes = {
+  admin: PropTypes.object.isRequired,
   config: PropTypes.object.isRequired,
 };
 

--- a/src/containers/tests/header.spec.js
+++ b/src/containers/tests/header.spec.js
@@ -3,7 +3,10 @@ import { mount } from 'enzyme';
 import { Header } from '../Header';
 import { config } from './fixtures';
 
-const defaultProps = { config: config.content };
+const defaultProps = {
+  admin: {},
+  config: config.content
+};
 
 function setup(props = defaultProps) {
   const component = mount(
@@ -12,7 +15,8 @@ function setup(props = defaultProps) {
 
   return {
     component: component,
-    title: component.find('h3 span')
+    title: component.find('h3 span'),
+    version: component.find('.version')
   };
 }
 
@@ -29,5 +33,12 @@ describe('Containers::Header', () => {
     }));
     const { config } = component.props();
     expect(title.text()).toEqual('You have no title!');
+  });
+
+  it('should render app version', () => {
+    const { component, version } = setup(Object.assign({}, defaultProps, {
+      admin: { version: '0.1.0' }
+    }));
+    expect(version.text()).toEqual('0.1.0');
   });
 });


### PR DESCRIPTION
Use admin version info from `meta` object passed to `<Dashboard />`
This additionally eliminates the need to update `src/constants/` at every release.