### PR TITLE
Add a special metafield for 'tags'

### DIFF
--- a/lib/jekyll-admin/server/dashboard.rb
+++ b/lib/jekyll-admin/server/dashboard.rb
@@ -25,6 +25,7 @@ module JekyllAdmin
       def dashboard_site_payload
         {
           "layouts"         => layout_names,
+          "tags"            => site.tags.keys,
           "content_pages"   => to_html_pages,
           "data_files"      => DataFile.all.map(&:relative_path),
           "static_files"    => site.static_files.map(&:relative_path),

--- a/spec/fixtures/site/_posts/2016-01-01-test-post.md
+++ b/spec/fixtures/site/_posts/2016-01-01-test-post.md
@@ -1,5 +1,8 @@
 ---
 foo: bar
+tags:
+- test
+- foo
 ---
 
 # Test Post

--- a/spec/fixtures/site/_posts/2016-02-01-test-post-2.md
+++ b/spec/fixtures/site/_posts/2016-02-01-test-post-2.md
@@ -1,5 +1,8 @@
 ---
 foo: bar
+tags:
+- test
+- safari
 ---
 
 # Test Post2

--- a/spec/fixtures/site/_posts/2016-03-01-test-post-3.md
+++ b/spec/fixtures/site/_posts/2016-03-01-test-post-3.md
@@ -1,5 +1,7 @@
 ---
 foo: bar
+tags:
+- highlight
 ---
 
 # Test Post with highlighting

--- a/src/components/metadata/MetaButtons.js
+++ b/src/components/metadata/MetaButtons.js
@@ -13,7 +13,7 @@ export class MetaButtons extends Component {
   }
 
   render() {
-    const { currentType, parentType, onDropdownFocus, onDropdownBlur } = this.props;
+    const { currentType, parentType, parentKey, onDropdownFocus, onDropdownBlur } = this.props;
     return (
       <div className="meta-buttons">
         {
@@ -35,7 +35,7 @@ export class MetaButtons extends Component {
               </span>
             }
             {
-              currentType != 'array' &&
+              parentKey != 'tags' && currentType != 'array' &&
               <span onMouseDown={() => this.handleTypeChange('array')}>
                 <i className="fa fa-list-ol"/>Convert to List
               </span>
@@ -65,7 +65,8 @@ MetaButtons.propTypes = {
   onConvertClick: PropTypes.func.isRequired,
   onRemoveClick: PropTypes.func.isRequired,
   onDropdownFocus: PropTypes.func.isRequired,
-  onDropdownBlur: PropTypes.func.isRequired
+  onDropdownBlur: PropTypes.func.isRequired,
+  parentKey: PropTypes.string
 };
 
 export default MetaButtons;

--- a/src/components/metadata/MetaField.js
+++ b/src/components/metadata/MetaField.js
@@ -56,6 +56,7 @@ export class MetaField extends Component {
           <MetaButtons
             currentType={type}
             parentType="top"
+            parentKey={fieldKey}
             onConvertClick={(type) => this.handleConvertClick(type)}
             onRemoveClick={() => this.handleRemoveClick()}
             onDropdownFocus={() => this.handleDropdownFocus()}

--- a/src/components/metadata/MetaObject.js
+++ b/src/components/metadata/MetaObject.js
@@ -12,6 +12,7 @@ export class MetaObject extends Component {
       let type = 'simple';
       if (_.isObject(value)) type = 'object';
       if (_.isArray(value)) type = 'array';
+      if (_.isArray(value) && key == 'tags') type = 'simple';
       return (
         <MetaObjectItem
           key={key}

--- a/src/components/metadata/MetaSimple.js
+++ b/src/components/metadata/MetaSimple.js
@@ -7,6 +7,7 @@ import StaticFiles from '../../containers/views/StaticFiles';
 import moment from 'moment';
 import momentLocalizer from 'react-widgets/lib/localizers/moment';
 import 'react-widgets/dist/css/react-widgets.css';
+import MetaTags from './MetaTags';
 
 momentLocalizer(moment);
 
@@ -128,6 +129,18 @@ export class MetaSimple extends Component {
     );
   }
 
+  renderTagsInput() {
+    const { fieldValue, nameAttr, updateFieldValue, appMeta } = this.props;
+
+    return (
+      <MetaTags
+        fieldValue={fieldValue}
+        nameAttr={nameAttr}
+        updateFieldValue={updateFieldValue}
+        suggestions={appMeta.site.tags} />
+    );
+  }
+
   render() {
     const { fieldKey } = this.props;
     let node;
@@ -141,6 +154,9 @@ export class MetaSimple extends Component {
         break;
       case 'layout':
         node = this.renderLayoutPicker();
+        break;
+      case 'tags':
+        node = this.renderTagsInput();
         break;
       default:
         node = this.renderEditable();

--- a/src/components/metadata/MetaTags.js
+++ b/src/components/metadata/MetaTags.js
@@ -1,0 +1,164 @@
+import React, { Component, PropTypes } from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
+import _ from 'underscore';
+import classnames from 'classnames';
+import { getDeleteMessage } from '../../constants/lang';
+
+export class MetaTags extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tagInput: '',
+      pageTags: props.fieldValue || [''],
+      autoSuggest: false
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ pageTags: nextProps.fieldValue });
+  }
+
+  componentDidUpdate() {
+    const { nameAttr, updateFieldValue } = this.props;
+    updateFieldValue(nameAttr, this.state.pageTags);
+  }
+
+  createTag(value) {
+    const { pageTags } = this.state;
+    const clone = pageTags.slice();
+
+    // create tags only if they do not exist already
+    if (!clone.includes(value)) {
+      clone.push(value);
+
+      this.setState({
+        pageTags: clone,
+        tagInput: '',
+        autoSuggest: false
+      });
+    }
+  }
+
+  deleteTag(index) {
+    const { pageTags } = this.state;
+    const clone = pageTags.slice();
+
+    const tagName = (index === -1) ? clone.slice(-1).pop() : clone[index];
+    const confirm = window.confirm(getDeleteMessage(`tag: ${tagName}`));
+
+    if (confirm) {
+      clone.splice(index, 1);
+      this.setState({ pageTags: clone });
+      this.refs.taginput.focus();
+    }
+  }
+
+  handleKeyDown(e) {
+    const { pageTags } = this.state;
+    const input = e.target.value;
+
+    // define tags with either the 'comma' key or the 'Enter' key, or the 'Spacebar' key
+    if (input.length > 0 &&
+      (e.keyCode === 188 || e.keyCode === 13 || e.keyCode === 32)) {
+      this.createTag(input);
+    } else if (pageTags.length > 0 && input.length === 0 && e.keyCode === 8) {
+      this.deleteTag(-1);
+    }
+  }
+
+  rectifyTags(str) {
+    const rectified = str.split(' ');
+    this.setState({ pageTags: rectified });
+  }
+
+  render() {
+    const { pageTags } = this.state;
+
+    let suggestions = this.props.suggestions || [];
+    suggestions = _.filter(suggestions, entry => {
+      return entry.startsWith(this.state.tagInput);
+    });
+
+    if (pageTags.length > 0 && !(pageTags instanceof(Array))) {
+      return (
+        <span className="meta-error">
+          Invalid array of tags! Found string: <b>"{pageTags}"</b><br/>
+          Click
+            <span onClick={() => this.rectifyTags(pageTags)}> here </span>
+          to correct.
+        </span>
+      );
+    }
+
+    const tagPool = pageTags.filter(Boolean); // fiter out nil or empty elements
+
+    const tags = _.map(tagPool, (tag, i) => {
+      return (
+        <span key={i} className="tag">
+          {tag}
+          <span className="delete-tag" onClick={(e) => this.deleteTag(i)} />
+        </span>
+      );
+    });
+
+    const suggests = _.map(suggestions, (item, i) => {
+      if (!pageTags.includes(item)) {
+        return (
+          <li key={i} onClick={(e) => this.createTag(item)}>
+            {item}
+          </li>
+        );
+      }
+    }).filter(Boolean);
+
+    const suggestionClasses = classnames({
+      'field': true,
+      'tag-suggestions': true,
+      'visible': this.state.autoSuggest
+    });
+
+    return (
+      <div className="tags-wrap">
+        <div className="field value-field">
+          {
+            tags.length > 0 &&
+            <div className="tags-list">{tags}</div>
+          }
+
+          <div className="tags-input">
+            <input
+              type="text"
+              onFocus={() => this.setState({ autoSuggest: true })}
+              onBlur={() => this.setState({ autoSuggest: false })}
+              onChange={(e) => this.setState({ tagInput: e.target.value })}
+              onKeyDown={(e) => this.handleKeyDown(e)}
+              value = {this.state.tagInput.replace(/,|\s+/, '')}
+              ref="taginput"/>
+
+            <TextareaAutosize
+              className="field value-field"
+              value={this.state.pageTags.toString()}
+              hidden />
+          </div>
+        </div>
+          {
+            suggests.length > 0 &&
+              <div className={suggestionClasses}>
+                <ul>{suggests}</ul>
+              </div>
+          }
+      </div>
+    );
+  }
+}
+
+MetaTags.propTypes = {
+  fieldValue: PropTypes.any,
+  updateFieldValue: PropTypes.func.isRequired,
+  nameAttr: PropTypes.any.isRequired,
+  suggestions: PropTypes.array
+};
+
+export default MetaTags;

--- a/src/components/metadata/tests/metasimple.spec.js
+++ b/src/components/metadata/tests/metasimple.spec.js
@@ -25,6 +25,7 @@ function setup(props = defaultProps) {
     editable: component.find('.value-field'),
     datepicker: component.find('.date-field'),
     layoutpicker: component.find('.layout-picker'),
+    tagsinput: component.find('.tags-input'),
     actions,
     props
   };
@@ -50,6 +51,15 @@ describe('Components::MetaSimple', () => {
     }));
     expect(datepicker.node).toBeTruthy();
     expect(editable.node).toBeFalsy();
+  });
+
+  it('should render tagsinput if field key is called "tags"', () => {
+    const { editable, tagsinput } = setup(Object.assign({}, defaultProps, {
+      fieldKey: 'tags',
+      fieldValue: ['page']
+    }));
+    expect(tagsinput.node).toBeTruthy();
+    expect(editable.node).toBeTruthy();
   });
 
   it('should call updateFieldValue when the input is changed', () => {

--- a/src/components/metadata/tests/metatags.spec.js
+++ b/src/components/metadata/tests/metatags.spec.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import MetaTags from '../MetaTags';
+
+const defaultProps = {
+  fieldValue: [],
+  nameAttr: 'metadata["tags"]'
+};
+
+function setup(props = defaultProps) {
+  const actions = {
+    updateFieldValue: jest.fn()
+  };
+
+  let component = mount(
+    <MetaTags {...props} {...actions} />
+  );
+
+  return {
+    component,
+    editable: component.find('.value-field input'),
+    actions,
+    props
+  };
+}
+
+describe('Components::MetaTags', () => {
+  it('should render an editable', () => {
+    const { component, editable } = setup();
+    expect(editable.node).toBeTruthy();
+  });
+
+  it('should render an editable with "null" fieldValue prop', () => {
+    const { component, editable } = setup(Object.assign({}, defaultProps, {
+      fieldValue: null
+    }));
+    expect(editable.node).toBeTruthy();
+  });
+
+  it('should render an error if fieldValue prop is a String', () => {
+    const { component, editable } = setup(Object.assign({}, defaultProps, {
+      fieldValue: 'foo'
+    }));
+    const error = 'Invalid array of tags! Found string: "foo"Click here to correct.';
+    expect(component.find('.meta-error').text()).toEqual(error);
+    expect(editable.node).toBeFalsy();
+  });
+
+  it('should create tags on certain keypresses', () => {
+    const { component, editable } = setup();
+    editable.node.value = 'foo';
+    editable.simulate('change', editable);
+    expect(component.state('tagInput')).toEqual('foo');
+    editable.simulate('keyDown', {key: 'Enter', keyCode: 13} );
+    expect(component.state('pageTags')).toEqual(['foo']);
+
+    editable.node.value = 'bar';
+    editable.simulate('change', editable);
+    editable.simulate('keyDown', {key: 'Comma', keyCode: 188} );
+    expect(component.state('pageTags')).toEqual(['foo', 'bar']);
+
+    editable.node.value = 'ignored';
+    editable.simulate('change', editable);
+    editable.simulate('keyDown', {key: 'Tab', keyCode: 9} );
+    expect(component.state('pageTags')).not.toEqual(['foo', 'bar', 'ignored']);
+  });
+
+  it('should not create duplicate tags', () => {
+    const { component, editable } = setup(Object.assign({}, defaultProps, {
+      fieldValue: ['foo', 'bar']
+    }));
+    editable.node.value = 'foo';
+    editable.simulate('change', editable);
+    editable.simulate('keyDown', {key: 'Space', keyCode: 32} );
+    expect(component.state('pageTags')).not.toEqual(['foo', 'bar', 'foo']);
+  });
+
+  it('should delete tags on clicking "(x)"', () => {
+    const { component, editable } = setup();
+    editable.node.value = 'foo';
+    editable.simulate('change', editable);
+    editable.simulate('keyDown', {key: 'Space', keyCode: 32} );
+
+    component.find('.delete-tag').simulate('click');
+    expect(component.state('pageTags')).toEqual(['foo']); // TODO: pass prompt
+  });
+
+  it('should delete tags on pressing "backspace"', () => {
+    const { component, editable } = setup();
+    editable.node.value = 'foo';
+    editable.simulate('change', editable);
+    editable.simulate('keyDown', {key: 'Space', keyCode: 32} );
+    editable.simulate('keyDown', {key: 'Backspace', keyCode: 8} );
+    expect(component.state('pageTags')).toEqual(['foo']); // TODO: pass prompt
+  });
+
+  it('should call updateFieldValue when the input is changed', () => {
+    const { actions, editable } = setup();
+    editable.simulate('change');
+    expect(actions.updateFieldValue).toHaveBeenCalled();
+  });
+
+  it('should render a dropdown list of all tags in site payload', () => {
+    const { component, editable } = setup(Object.assign({}, defaultProps, {
+      suggestions: ['foo', 'bar', 'baz']
+    }));
+    component.setState({ autoSuggest: true });
+    const suggestedTags = component.find('.tag-suggestions li');
+    expect(suggestedTags.map((item) => item.text())).toEqual(['foo', 'bar', 'baz']);
+  });
+
+  it('should render a dropdown list of tags not already used in current document', () => {
+    const { component, editable } = setup(Object.assign({}, defaultProps, {
+      fieldValue: ['foo'],
+      suggestions: ['foo', 'bar', 'baz']
+    }));
+    component.setState({ autoSuggest: true });
+    const suggestedTags = component.find('.tag-suggestions li');
+    expect(suggestedTags.map((item) => item.text())).toEqual(['bar', 'baz']);
+  });
+
+  it('should create a tag from the dropdown list of suggested tags', () => {
+    const { component, editable } = setup(Object.assign({}, defaultProps, {
+      fieldValue: ['foo'],
+      suggestions: ['foo', 'bar', 'baz']
+    }));
+    component.setState({ autoSuggest: true });
+    const suggestedTags = component.find('.tag-suggestions li');
+    suggestedTags.first().simulate('click');
+    expect(component.state('pageTags')).toEqual(['foo', 'bar']);
+  });
+
+  it('should update with new props', () => {
+    const { component } = setup(Object.assign({}, defaultProps, {
+      fieldValue: ['foo']
+    }));
+    expect(component.state('pageTags')).toEqual(['foo']);
+    component.setProps({ fieldValue: ['lorem', 'ipsum'] });
+    expect(component.state('pageTags')).toEqual(['lorem', 'ipsum']);
+  });
+});

--- a/src/containers/MetaFields.js
+++ b/src/containers/MetaFields.js
@@ -43,6 +43,7 @@ export class MetaFields extends Component {
       let type = 'simple';
       if (_.isObject(field)) type = 'object';
       if (_.isArray(field)) type = 'array';
+      if (_.isArray(field) && key == 'tags') type = 'simple';
       return (
         <MetaField
           key={key}
@@ -80,7 +81,7 @@ export class MetaFields extends Component {
               <i className="fa fa-info-circle" />Special Keys
               <span className="tooltip-text">
                 You can use special keys like
-                <b> layout</b>, <b>date</b>, <b>file</b>, <b>image </b>
+                <b> layout</b>, <b>date</b>, <b>file</b>, <b>image</b>, and <b>tags </b>
                 for user-friendly functionalities.
               </span>
             </small>

--- a/src/styles/datagui.scss
+++ b/src/styles/datagui.scss
@@ -578,4 +578,30 @@
   .data-new {
     margin-top: 25px;
   }
+  .meta-error {
+    display: inline-block;
+    height: 48px;
+    margin-left: 15px;
+    padding: 14px 0;
+  }
+  .tags-list {
+    border-bottom-color: #121212;
+    + .tags-input { border-top-color: #424242; }
+  }
+  .tags-input input {
+    color: white;
+    background: #333;
+  }
+  .tag-suggestions {
+    border-color: #2b2b2b;
+    border-top-color: #222;
+    ul li {
+      color: #818181;
+      background-color: #2b2b2b;
+      &:hover {
+        color: #cdcdcd;
+        background-color: #454545;
+      }
+    }
+  }
 }

--- a/src/styles/metafields.scss
+++ b/src/styles/metafields.scss
@@ -539,6 +539,28 @@
   .meta-new {
     margin-top: 25px;
   }
+
+  .meta-error {
+    display: inline-block;
+    margin-left: 14px;
+    padding: 6px;
+    font-size: 15px;
+    line-height: 1.25;
+    span {
+      margin: 0 2px;
+      font-weight: bold;
+      cursor: pointer;
+      text-decoration: underline;
+    }
+  }
+}
+
+.meta-error {
+  color: $dark-red;
+  b {
+    margin-left: 5px;
+    color: $dark-red;
+  }
 }
 
 .layout-picker {
@@ -566,5 +588,82 @@
     .rw-btn {
       padding-top: 4px;
     }
+  }
+}
+
+.tags-wrap {
+  position: relative;
+  float: right;
+  right: 34px;
+  width: calc(100% - 240px);
+  pointer-events: auto;
+  z-index: 3;
+}
+
+.tags-list {
+  max-width: 809px;
+  padding-bottom: 11px;
+  border-bottom: 1px solid lighten($border-color, 7%);
+  + .tags-input {
+    padding-top: 11px;
+    border-top: 1px solid white;
+  }
+}
+
+.tag {
+  display: inline-block;
+  margin-right: 5px;
+  padding: 1px 5px;
+  font-size: 15px;
+  font-weight: 900;
+  color: #212121;
+  background: #ffd699;
+  @include border-radius(4px);
+  .delete-tag:after {
+    margin-left: 4px;
+    content: "\f057";
+    font-family: FontAwesome;
+    color: #cc8f33;
+    cursor: pointer;
+  }
+}
+
+.tags-input {
+  input {
+    width: 100%;
+    height: 24px;
+    background-color: $background-color;
+    border: none;
+    &:focus {
+      outline: none;
+    }
+  }
+}
+
+.tag-suggestions {
+  position: absolute;
+  display: table;
+  width: 100%;
+  margin-top: -10px;
+  padding: 0;
+  border-radius: 0;
+  opacity: 0;
+  visibility: collapse;
+  @include transition(0.5s);
+  ul {
+    padding: 0;
+    li {
+      padding: 10px 12px;
+      list-style: none;
+      font-weight: 700;
+      &:hover {
+        color: white;
+        background-color: $dark-orange;
+      }
+    }
+  }
+  &.visible {
+    opacity: 1;
+    visibility: visible;
   }
 }


### PR DESCRIPTION
Inspired by a request made at the upstream repo.

Notable features:
  - Create tags with a `comma` or `Spacebar` or `Enter` keystroke
  - Delete tags by `click` or by `Backspace` keystroke
  - Auto-suggestions based on input and existing `tags` in `site.tags` array
  - The `value-field` with this key cannot be switched to a `list` type.