### PR TITLE
Add support for static file directories

### DIFF
--- a/lib/jekyll-admin/directory.rb
+++ b/lib/jekyll-admin/directory.rb
@@ -46,7 +46,7 @@ module JekyllAdmin
     end
 
     def resource_path
-      types = %w(pages data drafts templates theme)
+      types = %w(pages data drafts static_files templates theme)
       if types.include?(content_type)
         "/#{content_type}/#{splat}/#{name}"
       else

--- a/lib/jekyll-admin/server/static_file.rb
+++ b/lib/jekyll-admin/server/static_file.rb
@@ -1,17 +1,16 @@
 module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/static_files" do
-      get do
-        json static_files.map(&:to_api)
+      get "/index" do
+        json site.static_files.map(&:to_api)
       end
 
-      get "/*" do
+      get "/?*" do
+        render_404 unless File.exist?(path)
         if requested_file
           json requested_file.to_api(:include_content => true)
-        elsif !static_files_for_path.empty?
-          json static_files_for_path.map(&:to_api)
         else
-          render_404
+          json entries.map(&:to_api)
         end
       end
 
@@ -35,6 +34,38 @@ module JekyllAdmin
 
       private
 
+      # returns relative path of root level directories that contain static files
+      def directory_names
+        static_files.map do |f|
+          File.dirname(f.path.sub("#{site.source}/", "")).split("/")[0]
+        end.uniq
+      end
+
+      def directory_files
+        static_files.find_all do |p|
+          sanitized_path(File.dirname(p.path)) == directory_path
+        end
+      end
+
+      def entries
+        args = {
+          :base         => site.source,
+          :content_type => "static_files",
+          :splat        => params["splat"].first,
+        }
+        # get all directories inside the requested directory
+        directory = JekyllAdmin::Directory.new(directory_path, args)
+        directories = directory.directories
+
+        # exclude root level directories which do not have static files
+        if params["splat"].first.empty?
+          directories = directories.select do |d|
+            directory_names.include? d.name.to_s
+          end
+        end
+        directories.concat(directory_files)
+      end
+
       def static_file_body
         if !request_payload["raw_content"].to_s.empty?
           request_payload["raw_content"].to_s
@@ -44,17 +75,7 @@ module JekyllAdmin
       end
 
       def static_files
-        site.static_files
-      end
-
-      def file_list_dir(path) end
-
-      def static_files_for_path
-        # Joined with / to ensure user can't do partial paths
-        base_path = File.join(path, "/")
-        static_files.select do |f|
-          f.path.start_with? base_path
-        end
+        site.static_files.select { |f| f.path.start_with? site.source }
       end
     end
   end

--- a/spec/jekyll-admin/server/static_file_spec.rb
+++ b/spec/jekyll-admin/server/static_file_spec.rb
@@ -9,7 +9,7 @@ describe "static_files" do
     it "returns the index" do
       get "/static_files"
       expect(last_response).to be_ok
-      expect(last_response_parsed.last["path"]).to eql("/assets/images/icon-dark.png")
+      expect(last_response_parsed.last["path"]).to eql("/static-file.txt")
     end
 
     it "doesn't include the encoded content" do
@@ -33,37 +33,14 @@ describe "static_files" do
   end
 
   it "returns a deep directory listing" do
-    files = ["/static-dir/file.txt", "/static-dir/b/file2.txt"]
+    files = ["/static-dir/file.txt", "/static-dir/foo/file2.txt"]
     files.each { |f| write_file f, "test" }
 
     get "/static_files/static-dir"
     expect(last_response).to be_ok
 
-    files.each do |file|
-      response = last_response_parsed.find { |r| r["path"] == file }
-      expect(response).to_not be_nil, "Could not find #{file} in response"
-      expect(response["extname"]).to eql(File.extname(file))
-    end
-
-    delete_file(*files)
-  end
-
-  it "returns a directory listing starting only at the root" do
-    files = ["/static-dir/file.txt", "/static-dir/b/file2.txt"]
-    files.each { |f| write_file f, "test" }
-
-    get "/static_files/static-dir/b"
-    expect(last_response).to be_ok
-
-    file = files.last
-    response = last_response_parsed.find { |r| r["path"] == file }
-    expect(response).to_not be_nil, "Could not find #{file} in response"
-    expect(response["extname"]).to eql(File.extname(file))
-
-    file = files.first
-    response = last_response_parsed.find { |r| r["path"] == "/#{file}" }
-    expect(response).to be_nil, "#{file} included in response"
-
+    expect(last_response_parsed.first["name"]).to eql("foo")
+    expect(last_response_parsed.last["name"]).to eql("file.txt")
     delete_file(*files)
   end
 

--- a/src/actions/staticfiles.js
+++ b/src/actions/staticfiles.js
@@ -2,22 +2,14 @@ import * as ActionTypes from '../constants/actionTypes';
 import _ from 'underscore';
 import { get } from '../utils/fetch';
 import { addNotification } from './notifications';
-import {
-  getSuccessMessage,
-  getErrorMessage,
-  getUploadSuccessMessage,
-  getUploadErrorMessage
-} from '../constants/lang';
-import {
-  staticfilesAPIUrl,
-  staticfileAPIUrl
-} from '../constants/api';
+import { getSuccessMessage, getErrorMessage, getUploadSuccessMessage, getUploadErrorMessage } from '../constants/lang';
+import { staticfilesAPIUrl, staticfileAPIUrl } from '../constants/api';
 
-export function fetchStaticFiles() {
-  return dispatch => {
+export function fetchStaticFiles(directory = '') {
+  return (dispatch) => {
     dispatch({ type: ActionTypes.FETCH_STATICFILES_REQUEST});
     return get(
-      staticfilesAPIUrl(),
+      staticfilesAPIUrl(directory),
       { type: ActionTypes.FETCH_STATICFILES_SUCCESS, name: 'files'},
       { type: ActionTypes.FETCH_STATICFILES_FAILURE, name: 'error'},
       dispatch
@@ -25,7 +17,7 @@ export function fetchStaticFiles() {
   };
 }
 
-export function uploadStaticFiles(files) {
+export function uploadStaticFiles(directory, files) {
   return (dispatch) => {
     _.each(files, file => {
       const reader = new FileReader();
@@ -35,13 +27,13 @@ export function uploadStaticFiles(files) {
           encoded_content: reader.result.split('base64,')[1]
         });
         // send the put request
-        return fetch(staticfileAPIUrl(file.name), {
+        return fetch(staticfileAPIUrl(directory, file.name), {
           method: 'PUT',
           body: payload
         })
         .then(data => {
           dispatch({ type: ActionTypes.PUT_STATICFILE_SUCCESS });
-          dispatch(fetchStaticFiles());
+          dispatch(fetchStaticFiles(directory));
           dispatch(addNotification(
             getSuccessMessage(),
             getUploadSuccessMessage(file.name),
@@ -64,14 +56,14 @@ export function uploadStaticFiles(files) {
   };
 }
 
-export function deleteStaticFile(filename) {
+export function deleteStaticFile(directory, filename) {
   return (dispatch) => {
-    return fetch(staticfileAPIUrl(filename), {
+    return fetch(staticfileAPIUrl(directory, filename), {
       method: 'DELETE'
     })
     .then(data => {
       dispatch({ type: ActionTypes.DELETE_STATICFILE_SUCCESS });
-      dispatch(fetchStaticFiles());
+      dispatch(fetchStaticFiles(directory));
     })
     .catch(error => dispatch({
       type: ActionTypes.DELETE_STATICFILE_FAILURE,

--- a/src/actions/tests/staticfiles.spec.js
+++ b/src/actions/tests/staticfiles.spec.js
@@ -15,9 +15,9 @@ describe('Actions::StaticFiles', () => {
     nock.cleanAll();
   });
 
-  it('fetches static files successfully', () => {
+  it('fetches all static files successfully', () => {
     nock(API)
-      .get('/static_files')
+      .get('/static_files/index')
       .reply(200, [staticfile]);
 
     const expectedActions = [
@@ -27,7 +27,7 @@ describe('Actions::StaticFiles', () => {
 
     const store = mockStore({ files: [] });
 
-    return store.dispatch(actions.fetchStaticFiles())
+    return store.dispatch(actions.fetchStaticFiles('index'))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -99,7 +99,7 @@ describe('Actions::StaticFiles', () => {
 
     const store = mockStore({ files: [] });
 
-    return store.dispatch(actions.deleteStaticFile('index.html'))
+    return store.dispatch(actions.deleteStaticFile(null, 'index.html'))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -14,6 +14,8 @@ export default class Breadcrumbs extends Component {
       base = `${ADMIN_PREFIX}/${type}`;
     } else if (type == 'data files') {
       base = `${ADMIN_PREFIX}/datafiles`;
+    } else if (type == 'static files') {
+      base = `${ADMIN_PREFIX}/staticfiles`;
     } else {
       base = `${ADMIN_PREFIX}/collections/${type}`;
     }

--- a/src/components/Dropzone.js
+++ b/src/components/Dropzone.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import _ from 'underscore';
 import ReactDropzone from 'react-dropzone';
 import FilePreview from './FilePreview';
+import Splitter from './Splitter';
 
 export class Dropzone extends Component {
 
@@ -10,7 +11,7 @@ export class Dropzone extends Component {
   }
 
   render() {
-    const { files, onDrop, onClickDelete, onClickItem } = this.props;
+    const { files, splat, onDrop, onClickDelete, onClickItem } = this.props;
     let node;
     if (files.length) {
       node = (
@@ -22,10 +23,15 @@ export class Dropzone extends Component {
                   key={i}
                   onClick={onClickItem}
                   onClickDelete={onClickDelete}
+                  splat={splat}
                   file={file} />
               );
             })
           }
+          <Splitter />
+          <div className="preview-tip">
+            Drag and drop file(s) here to upload additional items
+          </div>
         </div>
       );
     } else {
@@ -52,6 +58,7 @@ export class Dropzone extends Component {
 
 Dropzone.propTypes = {
   files: PropTypes.array.isRequired,
+  splat: PropTypes.string.isRequired,
   onDrop: PropTypes.func.isRequired,
   onClickDelete: PropTypes.func.isRequired,
   onClickItem: PropTypes.func,

--- a/src/components/FilePreview.js
+++ b/src/components/FilePreview.js
@@ -5,16 +5,16 @@ import { getFilenameFromPath } from '../utils/helpers';
 export default class FilePreview extends Component {
 
   handleClickDelete(path) {
-    const { onClickDelete } = this.props;
+    const { splat, onClickDelete } = this.props;
     const filename = getFilenameFromPath(path);
     const confirm = window.confirm(getDeleteMessage(filename));
     if (confirm) {
-      onClickDelete(filename);
+      onClickDelete(splat, filename);
     }
   }
 
   render() {
-    const { onClick, file } = this.props;
+    const { onClick, file, splat } = this.props;
     const extension = file.extname.substring(1);
     const image = /png|jpg|gif|jpeg|svg|ico/i.test(extension);
     let node;
@@ -38,7 +38,7 @@ export default class FilePreview extends Component {
           <i className="fa fa-diamond" aria-hidden="true" title="Theme Asset" />
         </span>
       );
-    } else {
+    } else if (splat != 'index') {
       overlay = (
         <button onClick={() => this.handleClickDelete(file.path)} className="delete" title="Delete file">x</button>
       );
@@ -56,6 +56,7 @@ export default class FilePreview extends Component {
 
 FilePreview.propTypes = {
   file: PropTypes.object.isRequired,
-  onClickDelete: PropTypes.func.isRequired,
+  splat: PropTypes.string.isRequired,
+  onClickDelete: PropTypes.func,
   onClick: PropTypes.func
 };

--- a/src/components/metadata/MetaSimple.js
+++ b/src/components/metadata/MetaSimple.js
@@ -3,7 +3,7 @@ import TextareaAutosize from 'react-textarea-autosize';
 import DateTimePicker from 'react-widgets/lib/DateTimePicker';
 import DropdownList from 'react-widgets/lib/DropdownList';
 import Modal from 'react-modal';
-import StaticFiles from '../../containers/views/StaticFiles';
+import StaticIndex from '../../containers/views/StaticIndex';
 import moment from 'moment';
 import momentLocalizer from 'react-widgets/lib/localizers/moment';
 import 'react-widgets/dist/css/react-widgets.css';
@@ -105,10 +105,15 @@ export class MetaSimple extends Component {
                 zIndex: 10,
               },
               content: {
-                margin: 50,
+                margin: 20,
+                paddingTop: 0,
+                paddingRight: 10,
+                paddingLeft: 15,
               }
             }} >
-             <StaticFiles onClickStaticFile={(url) => this.onClickPickerItem(url)} />
+            <div className="content">
+              <StaticIndex onClickStaticFile={(url) => this.onClickPickerItem(url)} modalView={true} />
+            </div>
           </Modal>
         </span>
       </div>

--- a/src/components/tests/filepreview.spec.js
+++ b/src/components/tests/filepreview.spec.js
@@ -7,11 +7,12 @@ import { staticfile } from './fixtures';
 
 function setup(file=staticfile) {
   const actions = {
-    onClickDelete: jest.fn()
+    onClickDelete: jest.fn(),
+    onClick: jest.fn()
   };
 
   let component = mount(
-    <FilePreview file={file} {...actions} />
+    <FilePreview file={file} splat="" {...actions} />
   );
 
   return {

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -27,8 +27,9 @@ export const datafilesAPIUrl = (directory = '') => `${API}/data/${directory}`;
 export const datafileAPIUrl = (directory, filename) =>
   directory ? `${API}/data/${directory}/${filename}` : `${API}/data/${filename}`;
 
-export const staticfilesAPIUrl = () => `${API}/static_files`;
-export const staticfileAPIUrl = (filename) => `${API}/static_files/${filename}`;
+export const staticfilesAPIUrl = (directory = '') => `${API}/static_files/${directory}`;
+export const staticfileAPIUrl = (directory, filename) =>
+  directory ? `${API}/static_files/${directory}/${filename}` : `${API}/static_files/${filename}`;
 
 export const templatesAPIUrl = (directory = '') => `${API}/templates/${directory}`;
 export const templateAPIUrl = (directory, filename) =>

--- a/src/containers/views/StaticIndex.js
+++ b/src/containers/views/StaticIndex.js
@@ -1,0 +1,101 @@
+import React, { Component, PropTypes } from 'react';
+import { Link } from 'react-router';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import _ from 'underscore';
+import FilePreview from '../../components/FilePreview';
+import Button from '../../components/Button';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import InputSearch from '../../components/form/InputSearch';
+import { search } from '../../actions/utils';
+import { existingUploadedFilenames } from '../../utils/helpers';
+import { filterByFilename } from '../../reducers/staticfiles';
+import { getOverrideMessage } from '../../constants/lang';
+import { fetchStaticFiles } from '../../actions/staticfiles';
+import { ADMIN_PREFIX } from '../../constants';
+
+export class StaticIndex extends Component {
+
+  componentDidMount() {
+    const { fetchStaticFiles } = this.props;
+    fetchStaticFiles('index');
+  }
+
+  render() {
+    const { isFetching } = this.props;
+
+    if (isFetching) {
+      return null;
+    }
+
+    const { files, search, onClickStaticFile, modalView } = this.props;
+
+    let node;
+    if (files.length) {
+      node = (
+        <div className="preview-container">
+          {
+            _.map(files, (file, i) => {
+              return (
+                <FilePreview
+                  key={i}
+                  onClick={onClickStaticFile}
+                  splat="index"
+                  file={file} />
+              );
+            })
+          }
+        </div>
+      );
+    } else {
+      node = (
+        <div className="preview-info">
+          <i className="fa fa-exclamation-triangle" aria-hidden="true" />
+          <h2>No files found!</h2>
+          <h4>Upload files at 'Directory Listing' to have them displayed here.</h4>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <div className="content-header">
+          <Breadcrumbs type="static files" splat="" />
+          {
+            !modalView &&
+              <div className="page-buttons">
+                <Link className="btn btn-view" to={`${ADMIN_PREFIX}/staticfiles`}>
+                  Directory Listing
+                </Link>
+              </div>
+          }
+          <div className="pull-right">
+            <InputSearch searchBy="filename" search={search} />
+          </div>
+        </div>
+        <div className="static-list">{node}</div>
+      </div>
+    );
+  }
+}
+
+StaticIndex.propTypes = {
+  files: PropTypes.array.isRequired,
+  isFetching: PropTypes.bool.isRequired,
+  fetchStaticFiles: PropTypes.func.isRequired,
+  search: PropTypes.func.isRequired,
+  onClickStaticFile: PropTypes.func,
+  modalView: PropTypes.bool
+};
+
+const mapStateToProps = (state) => ({
+  files: filterByFilename(state.staticfiles.files, state.utils.input),
+  isFetching: state.staticfiles.isFetching
+});
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({
+  fetchStaticFiles,
+  search
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(StaticIndex);

--- a/src/containers/views/tests/staticindex.spec.js
+++ b/src/containers/views/tests/staticindex.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { StaticFiles } from '../StaticFiles';
+import { StaticIndex } from '../StaticIndex';
 
 import { staticfile } from './fixtures';
 
@@ -14,10 +14,9 @@ function setup(files=[staticfile]) {
   };
 
   const component = mount(
-    <StaticFiles
+    <StaticIndex
       files={files}
       isFetching={false}
-      params={{ splat: '' }}
       {...actions} />
   );
 
@@ -29,7 +28,7 @@ function setup(files=[staticfile]) {
   };
 }
 
-describe('Containers::StaticFiles', () => {
+describe('Containers::StaticIndex', () => {
   it('should render correctly', () => {
     const { info, previewContainer } = setup();
     expect(info.node).toBeFalsy();
@@ -44,12 +43,6 @@ describe('Containers::StaticFiles', () => {
 
   it('should call fetchStaticFiles action after mounted', () => {
     const { actions } = setup();
-    expect(actions.fetchStaticFiles).toHaveBeenCalled();
-  });
-
-  it('should call fetchStaticFiles action again after props change', () => {
-    const { component, actions } = setup();
-    component.setProps({ params: { splat: 'assets' } });
     expect(actions.fetchStaticFiles).toHaveBeenCalled();
   });
 });

--- a/src/routes.js
+++ b/src/routes.js
@@ -18,6 +18,7 @@ import Drafts from './containers/views/Drafts';
 import DraftEdit from './containers/views/DraftEdit';
 import DraftNew from './containers/views/DraftNew';
 import StaticFiles from './containers/views/StaticFiles';
+import StaticIndex from './containers/views/StaticIndex';
 import Templates from './containers/views/Templates';
 import TemplateDirectory from './containers/views/TemplateDirectory';
 import TemplateEdit from './containers/views/TemplateEdit';
@@ -57,7 +58,11 @@ export default (
       <Route path="(**/)*.*" component={DataFileEdit} />
       <Route path="**" component={DataFiles} />
     </Route>
-    <Route path="staticfiles" component={StaticFiles} />
+    <Route path="staticfiles">
+      <IndexRoute component={StaticFiles} />
+      <Route path="index" component={StaticIndex} />
+      <Route path="**" component={StaticFiles} />
+    </Route>
     <Route path="templates">
       <IndexRoute component={Templates} />
       <Route path="(**/)new" component={TemplateNew} />

--- a/src/styles/staticfiles.scss
+++ b/src/styles/staticfiles.scss
@@ -3,8 +3,7 @@
   padding: 20px;
   color: #9098A3;
   background-color: white;
-  border: 1px solid $border-color;
-  @include border-radius($border-radius);
+  border: 2px dashed lighten($border-color, 5%);
   position: relative;
   .preview-info {
     padding: 40px;
@@ -23,6 +22,12 @@
   color: white;
 }
 
+.static-list {
+  padding: 25px;
+  background-color: #fafafa;
+  border: 1px solid lighten($border-color, 7%);
+}
+
 .preview-container {
   display: flex;
   flex-wrap: wrap;
@@ -39,14 +44,15 @@
     }
     a { height: 150px; }
     div {
+      display: table;
       width: 150px;
       height: 150px;
       text-align: center;
       i {
+        display: table-cell;
         color: #ccc;
-        padding-top: 50px;
         font-size: 64px;
-        display: inline-table;
+        vertical-align: middle;
       }
     }
     span.theme-indicator {
@@ -98,6 +104,28 @@
       background: #cf3f3f;
       border: none;
     }
+  }
+  .splitter {
+    margin-top: 25px;
+    opacity: 0.5
+  }
+  .preview-tip {
+    width: calc(100% - 0px); // override flex-wrap css
+  }
+}
+
+.preview-info {
+  padding: 20px;
+  text-align: center;
+  color: darken($background-color, 35%);
+  i {
+    display: inline;
+    font-size: 96px;
+    margin: 0;
+  }
+  h2, h4 {
+    margin: 0;
+    line-height: 1.5;
   }
 }
 


### PR DESCRIPTION
### Highlights
  - Drag & Drop or Upload static files into **existing** directories
  - View all static files read into memory by clicking on `Index Listing` button &mdash; useful for `staticfile-picker` metafield
  - `Index Listing` is a read-only view &mdash; only supports rendering and searching through the entire `site.static_files` array