### PR TITLE
Render 'layout' metafield by default

### DIFF
--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -125,8 +125,14 @@ export class DocumentEdit extends Component {
     const filename = rest.join('.');
     const docPath = directory ? `${directory}/${filename}` : filename;
 
+    const layout = front_matter.layout || '';
+
     const inputPath = <InputPath onChange={updatePath} type={collection} path={docPath} />;
-    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: docPath, ...front_matter}} />;
+    const metafields = (
+      <Metadata
+        ref="frontmatter"
+        fields={{ layout, title, raw_content, path: docPath, ...front_matter }} />
+    );
 
     const keyboardHandlers = {
       'save': this.handleClickSave,

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -104,7 +104,7 @@ export class DocumentNew extends Component {
               label="Edit Front Matter"
               overflow={true}
               height={this.state.panelHeight}
-              panel={<Metadata fields={{}} ref="frontmatter"/>} />
+              panel={<Metadata fields={{ 'layout': '' }} ref="frontmatter" />} />
 
             <Splitter />
 

--- a/src/containers/views/DraftEdit.js
+++ b/src/containers/views/DraftEdit.js
@@ -133,9 +133,15 @@ export class DraftEdit extends Component {
     const { name, relative_path, raw_content, collection, http_url, front_matter } = draft;
     const [directory, ...rest] = params.splat;
 
-    const title = front_matter && front_matter.title ? front_matter.title : '';
+    const layout = front_matter.layout || '';
+    const title = front_matter.title || '';
+
     const inputPath = <InputPath onChange={updatePath} type="drafts" path={relative_path} />;
-    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: relative_path, ...front_matter}} />;
+    const metafields = (
+      <Metadata
+        ref="frontmatter"
+        fields={{ layout, title, raw_content, path: relative_path, ...front_matter }} />
+    );
 
     return (
       <HotKeys

--- a/src/containers/views/DraftNew.js
+++ b/src/containers/views/DraftNew.js
@@ -99,7 +99,7 @@ export class DraftNew extends Component {
               label="Edit Front Matter"
               overflow={true}
               height={this.state.panelHeight}
-              panel={<Metadata fields={{}} ref="frontmatter"/>} />
+              panel={<Metadata fields={{ 'layout': '' }} ref="frontmatter" />} />
 
             <Splitter />
 

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -114,10 +114,13 @@ export class PageEdit extends Component {
     const { name, path, raw_content, http_url, front_matter } = page;
     const [directory, ...rest] = params.splat;
 
-    const title = front_matter && front_matter.title ? front_matter.title : '';
+    const layout = front_matter.layout || '';
+    const title = front_matter.title || '';
 
     const inputPath = <InputPath onChange={updatePath} type="pages" path={path} />;
-    const metafields = <Metadata ref="frontmatter" fields={{title, raw_content, path: path, ...front_matter}} />;
+    const metafields = (
+      <Metadata ref="frontmatter" fields={{ layout, title, raw_content, path: path, ...front_matter }} />
+    );
 
     return (
       <HotKeys

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -97,7 +97,7 @@ export class PageNew extends Component {
               label="Edit Front Matter"
               overflow={true}
               height={this.state.panelHeight}
-              panel={<Metadata fields={{}} ref="frontmatter"/>} />
+              panel={<Metadata fields={{ 'layout': '' }} ref="frontmatter" />} />
 
             <Splitter />
 


### PR DESCRIPTION
Render the metafield for `layout` key by default.
Users then need not create this field manually for every `Page`, `Document` or `Draft`. Simply select from available ones or `none`

(`Remove field` to delete defined key)