### PR TITLE
Replace 'neatjson' with 'oj'

### DIFF
--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sinatra", "~> 1.4"
   spec.add_dependency "sinatra-contrib", "~> 1.4"
   spec.add_dependency "addressable", "~> 2.4"
-  spec.add_dependency "neatjson", "~> 0.8"
+  spec.add_dependency "oj", "~> 3.3.2"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/jekyll-admin.rb
+++ b/lib/jekyll-admin.rb
@@ -4,12 +4,11 @@
 # as it looks for sinatra/cross-origin, which is development only
 ENV["RACK_ENV"] = "production" if ENV["RACK_ENV"].to_s.empty?
 
-require "json"
+require "oj" # Optimized JSON. https://github.com/ohler55/oj
 require "jekyll"
 require "base64"
 require "webrick"
 require "sinatra"
-require "neatjson"
 require "fileutils"
 require "sinatra/base"
 require "sinatra/json"

--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -36,8 +36,13 @@ module JekyllAdmin
 
     def json(object, options = {})
       content_type :json
-      options = { :aligned => true, :around_colon => 1 }.merge options
-      JSON.neat_generate(object, options)
+      pretty_options = {
+        :array_nl  => "\n",
+        :object_nl => "\n",
+        :indent    => "  ",
+        :space     => " ",
+      }.merge(options)
+      Oj.generate(object, pretty_options)
     end
 
     def site


### PR DESCRIPTION
Replacing `neatjson` because of a breaking bug due to escaping `#` in content such as `"#{foo}"`
Instead emulate `JSON.pretty_generate` with `Oj.generate` because the latter doesn't insert `\n` in empty arrays and objects.