### PR TITLE
Enable detecting custom config-file passed via the terminal 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,5 @@ Metrics/MethodLength:
   Max: 21
 Metrics/PerceivedComplexity:
   Max: 9
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/jekyll-manager.gemspec
+++ b/jekyll-manager.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", "~> 3.5"
+  spec.add_dependency "jekyll", "~> 3.6"
   spec.add_dependency "sinatra", "~> 1.4"
   spec.add_dependency "sinatra-contrib", "~> 1.4"
   spec.add_dependency "addressable", "~> 2.4"

--- a/lib/jekyll-admin/server/configuration.rb
+++ b/lib/jekyll-admin/server/configuration.rb
@@ -39,9 +39,15 @@ module JekyllAdmin
         )
       end
 
-      # Returns the path to the *first* config file discovered
+      # Returns the path to the *first* config file from the list passed to terminal
+      # switch +--config+ or the first of default config files to be discovered at the
+      # site's source directory.
       def configuration_path
-        sanitized_path configuration.config_files(overrides).first
+        if site.config["config"]
+          sanitized_path site.config["config"].first
+        else
+          sanitized_path configuration.config_files(overrides).first
+        end
       end
 
       # The user's uploaded configuration for updates

--- a/spec/fixtures/index.html
+++ b/spec/fixtures/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Jekyll Admin</title>
+    <title>Jekyll Manager</title>
     <link rel="shortcut icon" href="favicon.ico">
   <link rel="stylesheet" href="/admin/styles.css"></head>
   <body>

--- a/spec/fixtures/site/_config.yml
+++ b/spec/fixtures/site/_config.yml
@@ -8,6 +8,7 @@ plugins:
 theme: test-theme
 
 foo: bar
+url: ""
 
 # show draft posts
 show_drafts: true

--- a/spec/fixtures/site/_config_test.yml
+++ b/spec/fixtures/site/_config_test.yml
@@ -1,0 +1,2 @@
+title: Custom Test Site
+plugins: ["jekyll-manager"]

--- a/spec/jekyll-admin/custom_integration_spec.rb
+++ b/spec/jekyll-admin/custom_integration_spec.rb
@@ -1,7 +1,18 @@
-describe "integration" do
+describe "custom integration" do
   let(:source) { fixture_path("site") }
   let(:dest) { File.join(source, "_site") }
-  let(:args) { ["--detach", "--watch", "--source", source, "--destination", dest] }
+  let(:config) { File.join(source, "_config_test.yml") }
+
+  let(:args) do
+    [
+      "--detach",
+      "--watch",
+      "--source", source,
+      "--destination", dest,
+      "--config", config,
+    ]
+  end
+
   let(:start_command) { %w(bundle exec jekyll serve).concat(args) }
   let(:stop_command) { ["pkill", "-f", "jekyll"] }
   let(:server) { "http://localhost:4000" }
@@ -37,28 +48,11 @@ describe "integration" do
   end
 
   context "API" do
-    let(:path) { "/_api" }
+    let(:path) { "/_api/configuration" }
 
     it "serves the Jekyll site", :skip => Gem.win_platform? do
       expect(response.code).to eql("200")
-      expect(response.body).to match("collections_api")
-    end
-  end
-
-  context "watching" do
-    it "Jekyll isn't watching", :skip => Gem.win_platform? do
-      File.open(File.join(source, "page.md"), "a") do |f|
-        f.puts "peek-a-boo"
-      end
-      content = File.read(File.join(source, "page.md"))
-      output = File.read(File.join(dest, "page.html"))
-
-      expect(content).to include("peek-a-boo")
-      expect(output).not_to include("peek-a-boo")
-
-      File.open(File.join(source, "page.md"), "w+") do |f|
-        f.write "---\nfoo: bar\n---\n\n# Test Page\n"
-      end
+      expect(response.body).to match("Custom Test Site")
     end
   end
 end


### PR DESCRIPTION
With this the interface will use the custom config-file supplied to Jekyll via the terminal switch `--config`

If multiple files are passed to the switch, the first of such files will be used as a destination for the `PUT` requests at the `/configuration/` end-point.