### PR TITLE
Update jekyll-manager.gemspec for jekyll 4.0.0

### DIFF
--- a/jekyll-manager.gemspec
+++ b/jekyll-manager.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", "~> 3.7"
+  spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
   spec.add_dependency "sinatra", "~> 1.4"
   spec.add_dependency "sinatra-contrib", "~> 1.4"
   spec.add_dependency "addressable", "~> 2.4"


### PR DESCRIPTION
Following instructions at https://jekyllrb.com/news/2019/08/20/jekyll-4-0-0-released/ 

Using jekyll version 3.7 as lower bound from existing gemspec