### PR TITLE
Lint with rubocop-jekyll gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site/
+.gems/
 .sass-cache/
 .jekyll-metadata
 /.bundle/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,20 +1,26 @@
+require: rubocop-jekyll
 inherit_gem:
-  jekyll: .rubocop.yml
+  rubocop-jekyll: .rubocop.yml
 
 AllCops:
   Exclude:
     - lib/jekyll-admin/public/**/*
     - src/**/*
     - node_modules/**/*
-    - Gemfile
-    - jekyll-manager.gemspec
+    - vendor/**/*
 Metrics/AbcSize:
   Max: 22
 Metrics/BlockLength:
   Enabled: false
+Metrics/CyclomaticComplexity:
+  Max: 8
 Metrics/MethodLength:
   Max: 21
 Metrics/PerceivedComplexity:
   Max: 9
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+    - io
+    - id
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.2
+rvm: 2.4
 before_install:
   - nvm install 6
 install: script/bootstrap
@@ -9,7 +9,6 @@ cache:
   yarn: true
   directories:
     - node_modules
-sudo: false
 env:
   matrix:
     - TEST_SUITE=node

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in jekyll-manager.gemspec
 gemspec
 
 # Site dependencies
-gem 'jekyll-seo-tag'
-gem 'jekyll-sitemap'
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"
 
 # theme
 gem "test-theme", :path => File.expand_path("./spec/fixtures/test-theme", File.dirname(__FILE__))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   nodejs_version: "6"
   RACK_ENV: test
   JEKYLL_LOG_LEVEL: warn
-  RUBY_VERSION: 22
+  RUBY_VERSION: 24
   matrix:
     - TEST_SUITE: node
     - TEST_SUITE: ruby
@@ -10,7 +10,6 @@ environment:
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version
-  - gem install bundler --no-ri --no-rdoc --version '1.13.7'
   - bundle config --local path vendor/bundle
   - sh script/bootstrap
 

--- a/jekyll-manager.gemspec
+++ b/jekyll-manager.gemspec
@@ -1,7 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-manager/version'
+require "jekyll-manager/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-manager"
@@ -9,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ashwin Maroli"]
   spec.email         = ["ashmaroli@gmail.com"]
 
-  spec.summary       = %q{Jekyll Admin repackaged with some alterations}
+  spec.summary       = "Jekyll Admin repackaged with some alterations"
   spec.description   = "An administrative framework for Jekyll sites, Jekyll Manager " \
                        "is essentially Jekyll Admin repackaged with some alterations."
 
@@ -20,19 +19,18 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir.glob("lib/**/*").concat(%w(LICENSE README.md))
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r!^exe/!) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
+  spec.add_dependency "oj", "~> 3.3", ">= 3.3.2"
   spec.add_dependency "sinatra", "~> 1.4"
   spec.add_dependency "sinatra-contrib", "~> 1.4"
-  spec.add_dependency "addressable", "~> 2.4"
-  spec.add_dependency "oj", "~> 3.3", ">= 3.3.2"
 
   spec.add_development_dependency "bundler", ">= 1.7"
+  spec.add_development_dependency "gem-release", "~> 0.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "rubocop", "~> 0.48.1"
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.10.0"
   spec.add_development_dependency "sinatra-cross_origin", "~> 0.3"
-  spec.add_development_dependency "gem-release", "~> 0.7"
 end

--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -2,7 +2,6 @@ module JekyllAdmin
   # Abstract module to be included in Convertible and Document to provide
   # additional, API-specific functionality without duplicating logic
   module APIable
-
     CONTENT_FIELDS = %w(next previous content excerpt).freeze
 
     # Returns a hash suitable for use as an API response.
@@ -49,9 +48,7 @@ module JekyllAdmin
         output["relative_path"] = relative_path.sub("_drafts/", "") if draft?
       end
 
-      if is_a?(Jekyll::StaticFile)
-        output["from_theme"] = from_theme_gem?
-      end
+      output["from_theme"] = from_theme_gem? if is_a?(Jekyll::StaticFile)
 
       output
     end
@@ -94,6 +91,7 @@ module JekyllAdmin
 
     def front_matter
       return unless file_exists?
+
       @front_matter ||= if file_contents =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
                           SafeYAML.load(Regexp.last_match(1))
                         else
@@ -103,6 +101,7 @@ module JekyllAdmin
 
     def raw_content
       return unless file_exists?
+
       @raw_content ||= if file_contents =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
                          $POSTMATCH
                        else
@@ -116,6 +115,7 @@ module JekyllAdmin
 
     def file_exists?
       return @file_exists if defined? @file_exists
+
       @file_exists = File.exist?(file_path)
     end
 
@@ -158,6 +158,7 @@ module JekyllAdmin
 
     def url_fields
       return {} unless respond_to?(:http_url) && respond_to?(:api_url)
+
       {
         "http_url" => http_url,
         "api_url"  => api_url,

--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -14,7 +14,7 @@ module JekyllAdmin
     #
     # id - the file ID as passed from the API. This may or may not have an extension
     def initialize(id)
-      @id ||= File.extname(id).empty? ? "#{id}.yml" : id
+      @id = File.extname(id).empty? ? "#{id}.yml" : id
     end
     alias_method :relative_path, :id
 

--- a/lib/jekyll-admin/directory.rb
+++ b/lib/jekyll-admin/directory.rb
@@ -63,6 +63,7 @@ module JekyllAdmin
       path.entries.map do |entry|
         next if [".", ".."].include? entry.to_s
         next unless path.join(entry).directory?
+
         self.class.new(
           path.join(entry),
           :base => base, :content_type => content_type, :splat => splat

--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -1,6 +1,5 @@
 module JekyllAdmin
   module FileHelper
-
     # The file the user requested in the URL
     def requested_file
       find_by_path(path)

--- a/lib/jekyll-admin/path_helper.rb
+++ b/lib/jekyll-admin/path_helper.rb
@@ -45,6 +45,7 @@ module JekyllAdmin
     # Is this request renaming a file?
     def renamed?
       return false unless request_payload["path"]
+
       ensure_leading_slash(request_payload["path"]) != relative_path
     end
 
@@ -68,6 +69,7 @@ module JekyllAdmin
 
     def ensure_leading_slash(input)
       return input if input.nil? || input.empty? || input.start_with?("/")
+
       "/#{input}"
     end
 

--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -19,7 +19,7 @@ module JekyllAdmin
       register Sinatra::CrossOrigin
       enable  :cross_origin
       disable :allow_credentials
-      set :allow_methods, %i[delete get options post put]
+      set :allow_methods, [:delete, :get, :options, :post, :put]
     end
 
     get "/" do
@@ -82,9 +82,7 @@ module JekyllAdmin
       body << request_payload["raw_content"].to_s
       body << "\n"
     end
-    alias page_body document_body
-
-    private
+    alias_method :page_body, :document_body
 
     def request_body
       @request_body ||= begin

--- a/lib/jekyll-admin/server/configuration.rb
+++ b/lib/jekyll-admin/server/configuration.rb
@@ -2,10 +2,10 @@ module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/configuration" do
       get do
-        json({
+        json(
           :content     => parsed_configuration,
-          :raw_content => raw_configuration,
-        })
+          :raw_content => raw_configuration
+        )
       end
 
       put do

--- a/lib/jekyll-admin/server/dashboard.rb
+++ b/lib/jekyll-admin/server/dashboard.rb
@@ -2,9 +2,9 @@ module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/dashboard" do
       get do
-        json app_meta.merge!({
-          "site" => dashboard_site_payload,
-        })
+        json app_meta.merge!(
+          "site" => dashboard_site_payload
+        )
       end
 
       private

--- a/lib/jekyll-admin/server/draft.rb
+++ b/lib/jekyll-admin/server/draft.rb
@@ -37,9 +37,7 @@ module JekyllAdmin
       # file but reside in a separate directory, `<source_dir>/_drafts/`
       def drafts
         posts = site.collections.find { |l, _c| l == "posts" }
-        if posts
-          posts[1].docs.find_all { |d| d.output_ext == ".html" && d.draft? }
-        end
+        posts[1].docs.find_all { |d| d.output_ext == ".html" && d.draft? } if posts
       end
 
       # return drafts at the same level as directory
@@ -71,6 +69,7 @@ module JekyllAdmin
 
       def ensure_html_content
         return if html_content?
+
         content_type :json
         halt 422, json("error_message" => "Invalid file extension for drafts")
       end

--- a/lib/jekyll-admin/server/page.rb
+++ b/lib/jekyll-admin/server/page.rb
@@ -36,6 +36,7 @@ module JekyllAdmin
 
       def ensure_html_content
         return if html_content?
+
         content_type :json
         halt 422, json("error_message" => "Invalid file extension for pages")
       end

--- a/lib/jekyll-admin/server/template.rb
+++ b/lib/jekyll-admin/server/template.rb
@@ -103,6 +103,7 @@ module JekyllAdmin
 
       def write_front_matter?
         return false unless request_payload["front_matter"]
+
         true
       end
 

--- a/lib/jekyll-admin/server/theme.rb
+++ b/lib/jekyll-admin/server/theme.rb
@@ -3,7 +3,7 @@ module JekyllAdmin
     namespace "/theme" do
       get do
         ensure_theme
-        json({
+        json(
           :name        => theme.name,
           :version     => theme.version,
           :authors     => theme.authors.join(", "),
@@ -11,43 +11,43 @@ module JekyllAdmin
           :summary     => theme.summary,
           :description => theme.description,
           :path        => at_root,
-          :directories => entries.map(&:to_api),
-        })
+          :directories => entries.map(&:to_api)
+        )
       end
 
       get "/*?/?:path.:ext" do
         ensure_requested_file
-        json({
+        json(
           :name            => filename,
           :path            => file_path,
           :relative_path   => relative_path_of(file_path),
           :raw_content     => raw_content,
           :exist_at_source => exist_at_source?,
           :http_url        => http_url(file_path),
-          :api_url         => url,
-        })
+          :api_url         => url
+        )
       end
 
       get "/?*" do
         ensure_directory_in_theme
-        json({
+        json(
           :name    => splats.first.split("/").last || theme.name,
           :path    => at_root(splats.first),
-          :entries => entries.map(&:to_api).concat(subdir_entries),
-        })
+          :entries => entries.map(&:to_api).concat(subdir_entries)
+        )
       end
 
       put "/*?/?:path.:ext" do
         write_file write_path, raw_content
-        json({
+        json(
           :name            => filename,
           :path            => write_path,
           :relative_path   => relative_path_of(file_path),
           :raw_content     => raw_content,
           :exist_at_source => true,
           :http_url        => http_url(file_path),
-          :api_url         => url,
-        })
+          :api_url         => url
+        )
       end
 
       private

--- a/lib/jekyll-admin/urlable.rb
+++ b/lib/jekyll-admin/urlable.rb
@@ -2,11 +2,11 @@ module JekyllAdmin
   # Abstract module to be included in Convertible and Document to provide
   # additional, URL-specific functionality without duplicating logic
   module URLable
-
     # Absolute URL to the HTTP(S) rendered/served representation of this resource
     def http_url
       return if is_a?(Jekyll::Collection) || is_a?(JekyllAdmin::DataFile)
       return if is_a?(Jekyll::Document) && !collection.write?
+
       @http_url ||= Addressable::URI.new(
         :scheme => scheme, :host => host, :port => port,
         :path => path_with_base(JekyllAdmin.site.config["baseurl"], url)
@@ -23,6 +23,7 @@ module JekyllAdmin
 
     def entries_url
       return unless is_a?(Jekyll::Collection)
+
       "#{api_url}/entries"
     end
 

--- a/spec/jekyll-admin/apiable_spec.rb
+++ b/spec/jekyll-admin/apiable_spec.rb
@@ -1,5 +1,5 @@
 describe JekyllAdmin::APIable do
-  %i[page post].each do |type|
+  [:page, :post].each do |type|
     context type do
       subject do
         documents = Jekyll.sites.first.send("#{type}s".to_sym)

--- a/spec/jekyll-admin/data_file_spec.rb
+++ b/spec/jekyll-admin/data_file_spec.rb
@@ -31,19 +31,19 @@ describe JekyllAdmin::DataFile do
   end
 
   it "returns the hash" do
-    expect(subject.to_api).to eql({
+    expect(subject.to_api).to eql(
       "path"          => "/_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
       "ext"           => ".yml",
       "title"         => "Data File",
       "api_url"       => "http://localhost:4000/_api/data/data_file.yml",
-      "http_url"      => nil,
-    })
+      "http_url"      => nil
+    )
   end
 
   it "returns the hash with content" do
-    expect(subject.to_api(:include_content => true)).to eql({
+    expect(subject.to_api(:include_content => true)).to eql(
       "path"          => "/_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
@@ -54,7 +54,7 @@ describe JekyllAdmin::DataFile do
         "foo" => "bar",
       },
       "api_url"       => "http://localhost:4000/_api/data/data_file.yml",
-      "http_url"      => nil,
-    })
+      "http_url"      => nil
+    )
   end
 end

--- a/spec/jekyll-admin/server/data_spec.rb
+++ b/spec/jekyll-admin/server/data_spec.rb
@@ -14,12 +14,12 @@ describe "data" do
   end
 
   let(:response_with_content) do
-    base_response.merge({
+    base_response.merge(
       "raw_content" => "foo: bar\n",
       "content"     => {
         "foo" => "bar",
-      },
-    })
+      }
+    )
   end
 
   def app

--- a/spec/jekyll-admin/server_spec.rb
+++ b/spec/jekyll-admin/server_spec.rb
@@ -22,7 +22,7 @@ describe JekyllAdmin::Server do
   end
 
   it "responds to CORS preflight checks" do
-    options "/", {}, { "HTTP_ORIGIN" => "http://localhost:3000" }
+    options "/", {}, "HTTP_ORIGIN" => "http://localhost:3000"
     expect(last_response.status).to eql(204)
 
     expected = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ end
 
 def with_index_stubbed
   return yield if File.exist?(index_path)
+
   stub_index
   yield
   FileUtils.rm_f(index_path)


### PR DESCRIPTION
To stop inheriting `rubocop.yml` from the *latest* version of Jekyll as that may cause false CI failures for PRs in this project.

Miscellaneous developmental changes include:
- adding support for Bundler 2.0
- dropping test coverage for EOL Ruby 2.3 and older.