### PR TITLE
Lock Rubygems on Travis to v3.0.6 [skip appveyor]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm: 2.4
 before_install:
   - nvm install 8
-  - gem update --system --no-document --version 3.0.6
+  - gem update --system 3.0.6 --no-document
 install: script/bootstrap
 script: script/cibuild
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm: 2.4
 before_install:
   - nvm install 8
-  - gem update --system --no-document
+  - gem update --system --no-document --version 3.0.6
 install: script/bootstrap
 script: script/cibuild
 cache:


### PR DESCRIPTION
Since Travis hangs on Rubygems v3.1.1