### PR TITLE
Address deprecation warnings from Ruby 2.7

### DIFF
--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -86,7 +86,7 @@ module JekyllAdmin
     end
 
     def file_contents
-      @file_contents ||= File.read(file_path, file_read_options) if file_exists?
+      @file_contents ||= File.read(file_path, **file_read_options) if file_exists?
     end
 
     def file_read_options

--- a/lib/jekyll-admin/server/collection.rb
+++ b/lib/jekyll-admin/server/collection.rb
@@ -76,7 +76,7 @@ module JekyllAdmin
           :splat        => params["splat"].first,
         }
         # get the directories inside the requested directory
-        directory = JekyllAdmin::Directory.new(directory_path, args)
+        directory = JekyllAdmin::Directory.new(directory_path, **args)
         directories = directory.directories
         # merge directories with the documents at the same level
         directories.concat(directory_docs.sort_by(&:date).reverse)

--- a/lib/jekyll-admin/server/configuration.rb
+++ b/lib/jekyll-admin/server/configuration.rb
@@ -37,7 +37,7 @@ module JekyllAdmin
       def raw_configuration
         File.read(
           configuration_path,
-          Jekyll::Utils.merged_file_read_opts(site, {})
+          **Jekyll::Utils.merged_file_read_opts(site, {})
         )
       end
 

--- a/lib/jekyll-admin/server/data.rb
+++ b/lib/jekyll-admin/server/data.rb
@@ -54,7 +54,7 @@ module JekyllAdmin
           :splat        => splats.first,
         }
         # get all directories inside the requested directory
-        directory = JekyllAdmin::Directory.new(directory_path, args)
+        directory = JekyllAdmin::Directory.new(directory_path, **args)
         directories = directory.directories
 
         # exclude root level directories which do not have data files

--- a/lib/jekyll-admin/server/draft.rb
+++ b/lib/jekyll-admin/server/draft.rb
@@ -83,7 +83,7 @@ module JekyllAdmin
           :splat        => params["splat"].first,
         }
         # get the directories inside the requested directory
-        directory = JekyllAdmin::Directory.new(directory_path, args)
+        directory = JekyllAdmin::Directory.new(directory_path, **args)
         directories = directory.directories
 
         # exclude root level directories which do not have drafts

--- a/lib/jekyll-admin/server/page.rb
+++ b/lib/jekyll-admin/server/page.rb
@@ -76,7 +76,7 @@ module JekyllAdmin
           :splat        => params["splat"].first,
         }
         # get all directories inside the requested directory
-        directory = JekyllAdmin::Directory.new(directory_path, args)
+        directory = JekyllAdmin::Directory.new(directory_path, **args)
         directories = directory.directories
 
         # exclude root level directories which do not have pages

--- a/lib/jekyll-admin/server/static_file.rb
+++ b/lib/jekyll-admin/server/static_file.rb
@@ -56,7 +56,7 @@ module JekyllAdmin
           :splat        => params["splat"].first,
         }
         # get all directories inside the requested directory
-        directory = JekyllAdmin::Directory.new(directory_path, args)
+        directory = JekyllAdmin::Directory.new(directory_path, **args)
         directories = directory.directories
 
         # exclude root level directories which do not have static files

--- a/lib/jekyll-admin/server/template.rb
+++ b/lib/jekyll-admin/server/template.rb
@@ -70,7 +70,7 @@ module JekyllAdmin
           :content_type => "templates",
           :splat        => splats.first,
         }
-        Directory.new(directory_path, args).directories
+        Directory.new(directory_path, **args).directories
       end
 
       def template_directories
@@ -173,7 +173,7 @@ module JekyllAdmin
 
       def file_contents(file = requested_file)
         @file_contents ||= File.read(
-          file, Jekyll::Utils.merged_file_read_opts(site, {})
+          file, **Jekyll::Utils.merged_file_read_opts(site, {})
         )
       end
 

--- a/lib/jekyll-admin/server/theme.rb
+++ b/lib/jekyll-admin/server/theme.rb
@@ -85,7 +85,7 @@ module JekyllAdmin
           :content_type => "theme",
           :splat        => splats.first,
         }
-        Directory.new(directory_path, args).directories
+        Directory.new(directory_path, **args).directories
       end
 
       def subdir_entries
@@ -130,7 +130,7 @@ module JekyllAdmin
       end
 
       def raw_content
-        File.read(file_path, Jekyll::Utils.merged_file_read_opts(site, {}))
+        File.read(file_path, **Jekyll::Utils.merged_file_read_opts(site, {}))
       end
     end
   end


### PR DESCRIPTION
```
warning: Using the last argument as keyword parameters is deprecated
```