### PR TITLE
Bump Ruby dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,10 @@ gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"
 gem "jekyll-seo-tag"
 gem "jekyll-sitemap"
 
+gem "rack-test"
+gem "rspec"
+gem "rubocop-jekyll", "~> 0.14"
+gem "sinatra-cross_origin", "~> 0.3"
+
 # theme
 gem "test-theme", :path => "spec/fixtures/test-theme"

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-require "bundler/gem_tasks"
-task :default => :spec

--- a/jekyll-manager.gemspec
+++ b/jekyll-manager.gemspec
@@ -15,18 +15,12 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob("lib/**/*").concat(%w(LICENSE README.md))
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.add_runtime_dependency "jekyll", ">= 3.7", "< 5.0"
   spec.add_runtime_dependency "oj", "~> 3.12"
-  spec.add_runtime_dependency "sinatra", "~> 1.4"
-  spec.add_runtime_dependency "sinatra-contrib", "~> 1.4"
+  spec.add_runtime_dependency "rackup", "~> 2.0"
+  spec.add_runtime_dependency "sinatra", "~> 4.0"
+  spec.add_runtime_dependency "sinatra-contrib", "~> 4.0"
   spec.add_runtime_dependency "webrick", "~> 1.7"
-
-  spec.add_development_dependency "bundler", ">= 1.7"
-  spec.add_development_dependency "gem-release", "~> 0.7"
-  spec.add_development_dependency "rake", ">= 12.0"
-  spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "rubocop-jekyll", "~> 0.12.0"
-  spec.add_development_dependency "sinatra-cross_origin", "~> 0.3"
 end

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -16,8 +16,11 @@ module Jekyll
         end
 
         def jekyll_admin_monkey_patch(server)
-          server.mount "/admin", Rack::Handler::WEBrick, JekyllAdmin::StaticServer
-          server.mount "/_api",  Rack::Handler::WEBrick, JekyllAdmin::Server
+          require "rackup"
+
+          server.mount "/admin", Rackup::Handler::WEBrick, JekyllAdmin::StaticServer
+          server.mount "/_api",  Rackup::Handler::WEBrick, JekyllAdmin::Server
+
           Jekyll.logger.warn "Auto-regeneration:", "disabled by Jekyll Manager."
           Jekyll.logger.warn "", "The site will regenerate only via the Admin interface."
           Jekyll.logger.info "Jekyll Manager mode:", ENV["RACK_ENV"] || "production"

--- a/script/release
+++ b/script/release
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-script/build
-bundle exec gem release --tag


### PR DESCRIPTION
- Minimum required Ruby version: **2.7.0**
- Minimum required Sinatra & co.: **4.0.0**
- Minimum required `rubocop-jekyll`: **0.14.0**